### PR TITLE
Add support for parsing settings from URL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "eslint.run": "onType",
   "eslint.format.enable": true,
   "[javascript]": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1730,18 +1730,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -2790,14 +2778,6 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4764,17 +4744,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5941,29 +5910,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6195,34 +6141,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
-    },
-    "node_modules/terser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -7045,20 +6963,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
-    },
-    "node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/src/components/Board.url-settings.test.jsx
+++ b/src/components/Board.url-settings.test.jsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { vi, describe, test, beforeEach, afterEach, expect } from 'vitest';
+import { useBoardContext } from '../context/BoardContext';
+import Board from './Board';
+
+vi.mock('../context/BoardContext');
+
+// Mock the NewBoardTemplateModal component to keep DOM simple
+vi.mock('./modals/NewBoardTemplateModal', () => ({
+  default: ({ isOpen }) => (isOpen ? <div data-testid="template-modal">Template Modal</div> : null)
+}));
+
+// Mock the ExportBoardModal component
+vi.mock('./modals/ExportBoardModal', () => ({
+  default: ({ isOpen }) => (isOpen ? <div data-testid="export-modal">Export Modal</div> : null)
+}));
+
+describe('Board URL settings', () => {
+  const mockShowNotification = vi.fn();
+
+  const baseCtx = {
+    boardId: null,
+    boardRef: null,
+    boardTitle: 'Untitled Board',
+    setBoardTitle: vi.fn(),
+    columns: {},
+    sortByVotes: false,
+    setSortByVotes: vi.fn(),
+    votingEnabled: true,
+    updateVotingEnabled: vi.fn(),
+    downvotingEnabled: true,
+    updateDownvotingEnabled: vi.fn(),
+    multipleVotesAllowed: false,
+    updateMultipleVotesAllowed: vi.fn(),
+    retrospectiveMode: false,
+    updateRetrospectiveMode: vi.fn(),
+    resetAllVotes: vi.fn(),
+    createNewBoard: vi.fn().mockReturnValue('new-board-abc'),
+    openExistingBoard: vi.fn(),
+    updateBoardTitle: vi.fn(),
+    darkMode: true,
+    updateDarkMode: vi.fn(),
+    workflowPhase: 'CREATION',
+    user: { uid: 'u1' }
+  };
+
+  const originalURLSearchParams = window.URLSearchParams;
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useBoardContext.mockReturnValue({ ...baseCtx });
+
+    // Mock window.location with query params
+    delete window.location;
+    window.location = { origin: 'https://example.com', pathname: '/', search: '?sort=votes&theme=light' };
+
+    window.URLSearchParams = vi.fn().mockImplementation((s) => new originalURLSearchParams(s));
+  });
+
+  afterEach(() => {
+    window.URLSearchParams = originalURLSearchParams;
+    window.location = originalLocation;
+  });
+
+  test('applies theme from URL on first render (sort handled on creation)', () => {
+    render(
+      <DndProvider backend={HTML5Backend}>
+        <Board showNotification={mockShowNotification} />
+      </DndProvider>
+    );
+
+  const ctx = useBoardContext.mock.results.at(-1).value;
+  // sortByVotes is now treated as a board setting and not applied on initial load
+  expect(ctx.setSortByVotes).not.toHaveBeenCalled();
+    expect(ctx.updateDarkMode).toHaveBeenCalledWith(false); // theme=light => darkMode false
+    // Template modal opens (no board id)
+    expect(screen.getByTestId('template-modal')).toBeInTheDocument();
+  });
+});

--- a/src/context/BoardContext.jsx
+++ b/src/context/BoardContext.jsx
@@ -110,6 +110,9 @@ export const BoardProvider = ({ children }) => {
             if (boardData.settings.votesPerUser !== undefined) {
               setVotesPerUser(boardData.settings.votesPerUser);
             }
+            if (boardData.settings.sortByVotes !== undefined) {
+              setSortByVotes(boardData.settings.sortByVotes);
+            }
             if (boardData.settings.retrospectiveMode !== undefined) {
               setRetrospectiveMode(boardData.settings.retrospectiveMode);
             }
@@ -192,8 +195,8 @@ export const BoardProvider = ({ children }) => {
     }
   }, [boardId, user]);
 
-  // Create a new board with specified template columns and title
-  const createNewBoard = (templateColumns = null, boardTitle = 'Untitled Board') => {
+  // Create a new board with specified template columns, title, and optional settings overrides
+  const createNewBoard = (templateColumns = null, boardTitle = 'Untitled Board', settingsOverride = null) => {
     if (!user) {
       return null;
     }
@@ -219,6 +222,17 @@ export const BoardProvider = ({ children }) => {
       };
     });
 
+    // Only allow a safe subset of settings to be overridden on creation
+  const allowedOverrideKeys = ['votingEnabled', 'downvotingEnabled', 'multipleVotesAllowed', 'votesPerUser', 'retrospectiveMode', 'sortByVotes'];
+    const sanitizedOverrides = {};
+    if (settingsOverride && typeof settingsOverride === 'object') {
+      allowedOverrideKeys.forEach(k => {
+        if (settingsOverride[k] !== undefined) {
+          sanitizedOverrides[k] = settingsOverride[k];
+        }
+      });
+    }
+
     const initialData = {
       title: boardTitle,
       created: Date.now(),
@@ -228,9 +242,12 @@ export const BoardProvider = ({ children }) => {
         votingEnabled: true, // Default to enabled for new boards
         downvotingEnabled: true, // Default to enabled for new boards
         multipleVotesAllowed: false, // Default to not allowing multiple votes
+  sortByVotes: false, // Default to chronological
         retrospectiveMode: false, // Default to disabled (cards are visible)
         workflowPhase: WORKFLOW_PHASES.CREATION, // Default to creation phase
-        resultsViewIndex: 0 // Default to first result
+        resultsViewIndex: 0, // Default to first result
+        // Apply any overrides parsed from URL (validated/whitelisted)
+        ...sanitizedOverrides
       }
     };
 
@@ -280,6 +297,7 @@ export const BoardProvider = ({ children }) => {
         downvotingEnabled,
         multipleVotesAllowed,
         votesPerUser,
+  sortByVotes,
         retrospectiveMode,
         workflowPhase,
         resultsViewIndex,
@@ -301,6 +319,9 @@ export const BoardProvider = ({ children }) => {
           }
           if (newSettings.votesPerUser !== undefined) {
             setVotesPerUser(newSettings.votesPerUser);
+          }
+          if (newSettings.sortByVotes !== undefined) {
+            setSortByVotes(newSettings.sortByVotes);
           }
           if (newSettings.retrospectiveMode !== undefined) {
             setRetrospectiveMode(newSettings.retrospectiveMode);
@@ -328,6 +349,9 @@ export const BoardProvider = ({ children }) => {
       }
       if (newSettings.votesPerUser !== undefined) {
         setVotesPerUser(newSettings.votesPerUser);
+      }
+      if (newSettings.sortByVotes !== undefined) {
+        setSortByVotes(newSettings.sortByVotes);
       }
       if (newSettings.retrospectiveMode !== undefined) {
         setRetrospectiveMode(newSettings.retrospectiveMode);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -56,3 +56,77 @@ export const COMMON_EMOJIS = [
   // Food & drink
   '🍺', '🍔'
 ];
+
+/**
+ * Parse a boolean-like query param value.
+ * Accepts: true/false/1/0/yes/no/on/off (case-insensitive)
+ */
+export function parseBool(value) {
+  if (typeof value !== 'string') return undefined;
+  const v = value.trim().toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(v)) return true;
+  if (['false', '0', 'no', 'off'].includes(v)) return false;
+  return undefined;
+}
+
+/**
+ * Extracts supported settings from a query string for initial board creation and UI prefs.
+ * Returns an object with boardSettings (persisted on new board) and uiPrefs (non-persisted).
+ *
+ * Supported query params:
+ * - voting: boolean (enable voting)
+ * - downvotes: boolean (allow downvoting)
+ * - multivote: boolean (allow multiple votes per item)
+ * - votes: number (votes per user)
+ * - retro: boolean (retrospective mode on)
+ * - sort: 'votes' | 'chrono' (UI preference)
+ * - theme: 'dark' | 'light' (UI preference)
+ */
+export function parseUrlSettings(queryString) {
+  try {
+    const search = typeof queryString === 'string' ? queryString : '';
+    const params = new URLSearchParams(search.startsWith('?') ? search : `?${search}`);
+
+  // Board settings (persisted on new board creation only)
+  const boardSettings = {};
+
+    const voting = parseBool(params.get('voting'));
+    if (voting !== undefined) boardSettings.votingEnabled = voting;
+
+    const downvotes = parseBool(params.get('downvotes'));
+    if (downvotes !== undefined) boardSettings.downvotingEnabled = downvotes;
+
+    const multivote = parseBool(params.get('multivote'));
+    if (multivote !== undefined) boardSettings.multipleVotesAllowed = multivote;
+
+    const votes = params.get('votes');
+    if (votes != null && votes !== '') {
+      const n = parseInt(votes, 10);
+      if (!Number.isNaN(n) && n > 0 && n < 1000) boardSettings.votesPerUser = n;
+    }
+
+    const retro = parseBool(params.get('retro'));
+    if (retro !== undefined) boardSettings.retrospectiveMode = retro;
+
+    const sort = params.get('sort');
+    if (typeof sort === 'string') {
+      const s = sort.trim().toLowerCase();
+      if (s === 'votes') boardSettings.sortByVotes = true;
+      if (s === 'chrono' || s === 'chronological' || s === 'time') boardSettings.sortByVotes = false;
+    }
+
+    // UI-only preferences (not persisted as board settings)
+    const uiPrefs = {};
+
+    const theme = params.get('theme');
+    if (typeof theme === 'string') {
+      const t = theme.trim().toLowerCase();
+      if (t === 'dark') uiPrefs.darkMode = true;
+      if (t === 'light') uiPrefs.darkMode = false;
+    }
+
+  return { boardSettings, uiPrefs };
+  } catch {
+    return { boardSettings: {}, uiPrefs: {} };
+  }
+}

--- a/src/utils/helpers.test.js
+++ b/src/utils/helpers.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { parseUrlSettings } from './helpers';
+
+describe('parseUrlSettings', () => {
+  it('parses boolean flags, numbers, and sort', () => {
+    const { boardSettings, uiPrefs } = parseUrlSettings('?voting=true&downvotes=no&multivote=1&votes=7&retro=on&sort=votes&theme=light');
+    expect(boardSettings).toEqual({
+      votingEnabled: true,
+      downvotingEnabled: false,
+      multipleVotesAllowed: true,
+      votesPerUser: 7,
+      retrospectiveMode: true,
+      sortByVotes: true
+    });
+    expect(uiPrefs).toEqual({ darkMode: false });
+  });
+
+  it('ignores invalid numbers and unknown values', () => {
+  const { boardSettings, uiPrefs } = parseUrlSettings('?votes=abc&sort=unknown&theme=blue');
+    expect(boardSettings).toEqual({});
+    expect(uiPrefs).toEqual({});
+  });
+
+  it('handles plain query string without leading ?', () => {
+    const { boardSettings } = parseUrlSettings('voting=0&downvotes=off');
+    expect(boardSettings).toEqual({ votingEnabled: false, downvotingEnabled: false });
+  });
+});


### PR DESCRIPTION
To enable easy one click launching of a board (including choosing a template) used GPT-5 to add parsing of settings from the URL and apply them as necessary.

Example URL params:
retro=true&multivote=true&downvotes=false&template=retro