### PR TITLE
Add collapsible columns

### DIFF
--- a/src/components/Column.jsx
+++ b/src/components/Column.jsx
@@ -1,7 +1,7 @@
 import { ref, set, remove } from 'firebase/database';
 import { useState, useRef, useEffect } from 'react';
 import { useDrop } from 'react-dnd';
-import { Trash2, Plus } from 'react-feather';
+import { ChevronLeft, ChevronRight, Trash2, Plus } from 'react-feather';
 import { useBoardContext } from '../context/BoardContext';
 import { useNotification } from '../context/NotificationContext';
 import { addCard } from '../utils/boardUtils';
@@ -10,7 +10,7 @@ import { isGroupingAllowed, isCardCreationAllowed } from '../utils/workflowUtils
 import Card from './Card';
 import CardGroup from './CardGroup';
 
-function Column({ columnId, columnData, sortByVotes }) {
+function Column({ columnId, columnData, sortByVotes, collapsed, onToggleCollapse }) {
   const { 
     boardId, 
     moveCard, 
@@ -306,6 +306,41 @@ function Column({ columnId, columnData, sortByVotes }) {
     setDraggedCardForGrouping(null);
   };
 
+  // Count total cards in this column (including grouped cards)
+  const getCardCount = () => {
+    const cardCount = columnData.cards ? Object.keys(columnData.cards).length : 0;
+    return cardCount;
+  };
+
+  // Collapsed column view
+  if (collapsed) {
+    return (
+      <div
+        className="column collapsed"
+        onClick={() => onToggleCollapse(columnId)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggleCollapse(columnId); } }}
+        aria-label={`Expand ${title} column (${getCardCount()} cards)`}
+        title={`${title} — ${getCardCount()} cards. Click to expand.`}
+      >
+        <div className="column-header">
+          <span className="collapsed-card-count">{getCardCount()}</span>
+          <div className="collapsed-title-wrapper">
+            <span className="collapsed-title">{title}</span>
+          </div>
+          <button
+            className="collapse-toggle"
+            aria-label={`Expand ${title} column`}
+            onClick={e => { e.stopPropagation(); onToggleCollapse(columnId); }}
+          >
+            <ChevronRight size={16} />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="column">
       <div className="column-header">
@@ -333,6 +368,14 @@ function Column({ columnId, columnData, sortByVotes }) {
           </h2>
         )}
         <div className="column-actions">
+          <button
+            className="collapse-toggle icon-button"
+            title="Collapse column"
+            onClick={() => onToggleCollapse(columnId)}
+            aria-label="Collapse column"
+          >
+            <ChevronLeft aria-hidden="true" />
+          </button>
           {isCardCreationAllowed(workflowPhase, retrospectiveMode) && (
             <button className="icon-button" title="Delete Column" onClick={deleteColumn} aria-label="Delete column">
               <Trash2 aria-hidden="true" />

--- a/src/components/Column.test.jsx
+++ b/src/components/Column.test.jsx
@@ -35,7 +35,9 @@ vi.mock('./CardCreationIndicator', () => ({
 // Mock react-feather
 vi.mock('react-feather', () => ({
   Trash2: () => <div>trash-icon</div>,
-  Plus: () => <div>plus-icon</div>
+  Plus: () => <div>plus-icon</div>,
+  ChevronLeft: () => <div>chevron-left-icon</div>,
+  ChevronRight: () => <div>chevron-right-icon</div>
 }));
 
 // Mock utils
@@ -67,7 +69,7 @@ vi.mock('../context/NotificationContext', () => ({
 
 
 describe('Column Component', () => {
-  const mockProps = {
+const mockProps = {
     columnId: 'col1',
     columnData: {
       title: 'Test Column',
@@ -78,6 +80,8 @@ describe('Column Component', () => {
       groups: {}
     },
     sortByVotes: false,
+    collapsed: false,
+    onToggleCollapse: vi.fn()
   };
 
   const mockBoardContext = {
@@ -139,5 +143,57 @@ describe('Column Component', () => {
     expect(formEl.compareDocumentPosition(firstCardEl)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
+  });
+
+  describe('Column - Collapsed State', () => {
+    test('renders collapsed view when collapsed prop is true', () => {
+      const collapsedProps = { ...mockProps, collapsed: true };
+      render(<Column {...collapsedProps} />);
+      
+      const columnEl = document.querySelector('.column.collapsed');
+      expect(columnEl).toBeInTheDocument();
+      
+      const collapsedTitle = screen.getByText('Test Column');
+      expect(collapsedTitle).toHaveClass('collapsed-title');
+      
+      const cardCountBadge = screen.getByText('2');
+      expect(cardCountBadge).toHaveClass('collapsed-card-count');
+      
+      const expandButton = document.querySelector('.collapse-toggle');
+      expect(expandButton).toBeInTheDocument();
+      expect(expandButton).toHaveAttribute('aria-label', expect.stringMatching(/expand.*column/i));
+    });
+
+    test('calls onToggleCollapse when collapsed column is clicked', () => {
+      const onToggleCollapseMock = vi.fn();
+      const collapsedProps = { ...mockProps, collapsed: true, onToggleCollapse: onToggleCollapseMock };
+      render(<Column {...collapsedProps} />);
+      
+      const columnEl = document.querySelector('.column.collapsed');
+      fireEvent.click(columnEl);
+      
+      expect(onToggleCollapseMock).toHaveBeenCalledWith('col1');
+    });
+
+    test('renders expanded view when collapsed prop is false', () => {
+      render(<Column {...mockProps} />);
+      
+      const columnEl = document.querySelector('.column:not(.collapsed)');
+      expect(columnEl).toBeInTheDocument();
+      
+      const cards = screen.getAllByTestId('card');
+      expect(cards).toHaveLength(2);
+      
+      const collapseButton = screen.getByRole('button', { name: /collapse column/i });
+      expect(collapseButton).toBeInTheDocument();
+    });
+
+    test('does not render cards in collapsed state', () => {
+      const collapsedProps = { ...mockProps, collapsed: true };
+      render(<Column {...collapsedProps} />);
+      
+      const cards = screen.queryAllByTestId('card');
+      expect(cards).toHaveLength(0);
+    });
   });
 });

--- a/src/components/ColumnsContainer.jsx
+++ b/src/components/ColumnsContainer.jsx
@@ -1,11 +1,15 @@
+import { useCallback, useEffect, useState } from 'react';
 import { Plus } from 'react-feather';
 import { useBoardContext } from '../context/BoardContext';
 import { WORKFLOW_PHASES } from '../utils/workflowUtils';
 import Column from './Column';
 
+const STORAGE_KEY_PREFIX = 'kanbanish-collapsed-';
+
 /**
  * Renders the board columns grid with an optional "Add Column" button.
  * Columns are sorted by their ID prefix (a_, b_, c_) for consistent ordering.
+ * Manages per-column collapsed state, persisted to localStorage per board.
  *
  * @param {Object} props
  * @param {Object} props.columns - Column data keyed by column ID
@@ -13,7 +17,43 @@ import Column from './Column';
  * @param {Function} props.addNewColumn - Callback to add a new column
  */
 const ColumnsContainer = ({ columns, sortByVotes, addNewColumn }) => {
-  const { retrospectiveMode, workflowPhase } = useBoardContext();
+  const { retrospectiveMode, workflowPhase, boardId } = useBoardContext();
+
+  // Load collapsed columns from localStorage
+  const [collapsedColumns, setCollapsedColumns] = useState(() => {
+    if (!boardId) return new Set();
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY_PREFIX + boardId);
+      return stored ? new Set(JSON.parse(stored)) : new Set();
+    } catch {
+      return new Set();
+    }
+  });
+
+  // Persist collapsed state to localStorage whenever it changes
+  useEffect(() => {
+    if (!boardId) return;
+    try {
+      localStorage.setItem(
+        STORAGE_KEY_PREFIX + boardId,
+        JSON.stringify([...collapsedColumns])
+      );
+    } catch {
+      // localStorage full or unavailable — silently ignore
+    }
+  }, [collapsedColumns, boardId]);
+
+  const toggleCollapse = useCallback((columnId) => {
+    setCollapsedColumns(prev => {
+      const next = new Set(prev);
+      if (next.has(columnId)) {
+        next.delete(columnId);
+      } else {
+        next.add(columnId);
+      }
+      return next;
+    });
+  }, []);
 
   // Get columns sorted by their IDs to maintain consistent order
   const getSortedColumns = () => {
@@ -37,6 +77,8 @@ const ColumnsContainer = ({ columns, sortByVotes, addNewColumn }) => {
             columnId={columnId}
             columnData={columnData}
             sortByVotes={sortByVotes}
+            collapsed={collapsedColumns.has(columnId)}
+            onToggleCollapse={toggleCollapse}
           />
         ))}
 

--- a/src/components/ColumnsContainer.test.jsx
+++ b/src/components/ColumnsContainer.test.jsx
@@ -1,0 +1,166 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { useBoardContext } from '../context/BoardContext';
+import ColumnsContainer from './ColumnsContainer';
+
+// Mock react-feather
+vi.mock('react-feather', () => ({
+  Plus: () => <div>plus-icon</div>
+}));
+
+// Mock Column component
+vi.mock('./Column', () => ({
+  default: (props) => (
+    <div
+      data-testid={`column-${props.columnId}`}
+      data-collapsed={props.collapsed}
+      onClick={() => props.onToggleCollapse(props.columnId)}
+      role="button"
+    >
+      {props.columnData.title}
+    </div>
+  )
+}));
+
+// Mock workflowUtils
+vi.mock('../utils/workflowUtils', () => ({
+  WORKFLOW_PHASES: {
+    CREATION: 'CREATION',
+    GROUPING: 'GROUPING',
+    INTERACTIONS: 'INTERACTIONS',
+    INTERACTION_REVEAL: 'INTERACTION_REVEAL',
+    RESULTS: 'RESULTS',
+    POLL: 'POLL'
+  }
+}));
+
+// Mock BoardContext
+vi.mock('../context/BoardContext');
+
+describe('ColumnsContainer', () => {
+  const mockBoardContext = {
+    retrospectiveMode: false,
+    workflowPhase: 'CREATION',
+    boardId: 'test-board'
+  };
+
+  const mockColumns = {
+    a_col1: {
+      title: 'To Do',
+      cards: {
+        card1: { id: 'card1', content: 'Task 1', created: 1000 },
+        card2: { id: 'card2', content: 'Task 2', created: 2000 }
+      },
+      groups: {}
+    },
+    b_col2: {
+      title: 'In Progress',
+      cards: {},
+      groups: {}
+    },
+    c_col3: {
+      title: 'Done',
+      cards: {
+        card3: { id: 'card3', content: 'Completed', created: 3000 }
+      },
+      groups: {}
+    }
+  };
+
+  const mockAddNewColumn = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useBoardContext.mockReturnValue(mockBoardContext);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('renders all columns', () => {
+    render(
+      <ColumnsContainer
+        columns={mockColumns}
+        sortByVotes={false}
+        addNewColumn={mockAddNewColumn}
+      />
+    );
+
+    const col1 = screen.getByTestId('column-a_col1');
+    const col2 = screen.getByTestId('column-b_col2');
+    const col3 = screen.getByTestId('column-c_col3');
+
+    expect(col1).toBeInTheDocument();
+    expect(col2).toBeInTheDocument();
+    expect(col3).toBeInTheDocument();
+  });
+
+  test('passes collapsed prop based on state', () => {
+    render(
+      <ColumnsContainer
+        columns={mockColumns}
+        sortByVotes={false}
+        addNewColumn={mockAddNewColumn}
+      />
+    );
+
+    const col1 = screen.getByTestId('column-a_col1');
+    expect(col1).toHaveAttribute('data-collapsed', 'false');
+  });
+
+  test('persists collapsed state to localStorage', () => {
+    const { rerender } = render(
+      <ColumnsContainer
+        columns={mockColumns}
+        sortByVotes={false}
+        addNewColumn={mockAddNewColumn}
+      />
+    );
+
+    // Get the column element and click it to toggle collapse
+    const col1 = screen.getByTestId('column-a_col1');
+    fireEvent.click(col1);
+
+    // Re-render to ensure state update is applied
+    rerender(
+      <ColumnsContainer
+        columns={mockColumns}
+        sortByVotes={false}
+        addNewColumn={mockAddNewColumn}
+      />
+    );
+
+    // Check localStorage
+    const stored = localStorage.getItem('kanbanish-collapsed-test-board');
+    expect(stored).toBeDefined();
+    const collapsedIds = JSON.parse(stored);
+    expect(collapsedIds).toContain('a_col1');
+  });
+
+  test('loads collapsed state from localStorage', () => {
+    // Set up localStorage with collapsed column
+    localStorage.setItem(
+      'kanbanish-collapsed-test-board',
+      JSON.stringify(['a_col1'])
+    );
+
+    render(
+      <ColumnsContainer
+        columns={mockColumns}
+        sortByVotes={false}
+        addNewColumn={mockAddNewColumn}
+      />
+    );
+
+    // Check that the column has collapsed state
+    const col1 = screen.getByTestId('column-a_col1');
+    expect(col1).toHaveAttribute('data-collapsed', 'true');
+
+    // Other columns should not be collapsed
+    const col2 = screen.getByTestId('column-b_col2');
+    expect(col2).toHaveAttribute('data-collapsed', 'false');
+  });
+});

--- a/src/styles/components/columns.css
+++ b/src/styles/components/columns.css
@@ -33,6 +33,91 @@ main {
     height: fit-content;
     display: flex;
     flex-direction: column;
+    transition: min-width 0.3s ease, max-width 0.3s ease;
+    overflow: hidden;
+}
+/* Collapsed column state */
+.column.collapsed {
+    min-width: var(--column-collapsed-width);
+    max-width: var(--column-collapsed-width);
+    cursor: pointer;
+    align-self: stretch;
+}
+
+.column.collapsed .column-header {
+    padding: var(--space-sm) var(--space-xs);
+    border-bottom: none;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-sm);
+}
+
+.column.collapsed .column-content,
+.column.collapsed .column-actions {
+    display: none;
+}
+
+.collapsed-title-wrapper {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    min-height: 0;
+}
+
+.collapsed-title {
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    transform: rotate(180deg);
+    font-weight: 600;
+    font-size: var(--font-size-sm);
+    color: var(--text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-height: 200px;
+    line-height: 1.3;
+    padding: var(--space-xs) 0;
+}
+
+.collapsed-card-count {
+    font-size: var(--font-size-xs);
+    color: var(--text-muted);
+    background: var(--hover-bg);
+    border-radius: var(--radius-round);
+    padding: 2px 6px;
+    min-width: 20px;
+    text-align: center;
+    line-height: 1.4;
+}
+
+.collapse-toggle {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    transition: color var(--transition-speed) var(--transition-ease),
+               background-color var(--transition-speed) var(--transition-ease);
+}
+
+.collapse-toggle:hover {
+    color: var(--accent);
+    background-color: var(--hover-bg);
+}
+
+.column.collapsed .collapse-toggle {
+    margin-top: auto;
+    padding: var(--space-xs);
+}
+
+.column.collapsed:hover {
+    border-color: var(--accent);
 }
 
 .column-header {
@@ -167,6 +252,11 @@ main {
     .column {
         min-width: var(--column-width-mobile);
         max-width: var(--column-width-mobile);
+    }
+
+    .column.collapsed {
+        min-width: var(--column-collapsed-width);
+        max-width: var(--column-collapsed-width);
     }
 }
 

--- a/src/styles/components/variables.css
+++ b/src/styles/components/variables.css
@@ -99,6 +99,7 @@
     --column-width-mobile: 280px;
     --header-height: 3.5rem;
     --max-comments-height: 200px;
+    --column-collapsed-width: 48px;
 }
 
 /* Light theme variables */


### PR DESCRIPTION
## Summary

- Adds the ability to collapse kanban columns to a narrow 48px strip, freeing horizontal space on boards with many columns
- Collapsed columns show a vertical title, card count badge, and expand chevron; clicking anywhere on the strip expands them back
- Collapse state is persisted per-board in localStorage (not Firebase) — it's a local UI preference, not shared with other users

## Implementation

### New CSS (`columns.css`, `variables.css`)
- `--column-collapsed-width: 48px` custom property
- `.column.collapsed` with `align-self: stretch` so collapsed columns match sibling heights
- Vertical title via `writing-mode: vertical-rl` + `rotate(180deg)` for bottom-to-top reading
- Card count badge, collapse/expand toggle buttons, hover accent border
- Mobile responsive: collapsed width maintained at 48px on small screens

### `ColumnsContainer.jsx`
- Manages `collapsedColumns` as a `Set` of column IDs
- Persists to `localStorage` keyed by `kanbanish-collapsed-{boardId}`
- Loads initial state from localStorage on mount
- Passes `collapsed` boolean + `onToggleCollapse` callback to each `Column`

### `Column.jsx`
- Accepts `collapsed` and `onToggleCollapse` props
- Collapsed view: accessible `role="button"` with `aria-label`, keyboard support (Enter/Space)
- Expanded view: collapse toggle button (`ChevronLeft`) in column header actions

### Tests
- 4 new tests in `Column.test.jsx` covering collapsed rendering and toggle behavior
- 4 new tests in `ColumnsContainer.test.jsx` covering localStorage persistence and state management
- All 859 tests passing, lint clean, build passing

Closes #84