### PR TITLE
Add error boundaries, offline indicator, and Firebase retry logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,8 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import Board from './components/Board';
 import Dashboard from './components/Dashboard';
+import ErrorBoundary from './components/ErrorBoundary';
+import OfflineIndicator from './components/OfflineIndicator';
 import { BoardProvider, useBoardContext } from './context/BoardContext';
 import { NotificationProvider, useNotification } from './context/NotificationContext';
 import BOARD_TEMPLATES from './data/boardTemplates';
@@ -217,9 +219,12 @@ function DashboardGate({ onOpenBoard }) {
 
 function App() {
   return (
-    <NotificationProvider>
-      <AppContent />
-    </NotificationProvider>
+    <ErrorBoundary>
+      <NotificationProvider>
+        <OfflineIndicator />
+        <AppContent />
+      </NotificationProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -74,7 +74,8 @@ vi.mock('./utils/firebase', () => ({
 }));
 vi.mock('firebase/database', () => ({
   ref: vi.fn(() => ({})),
-  set: vi.fn(() => Promise.resolve())
+  set: vi.fn(() => Promise.resolve()),
+  onValue: vi.fn(() => vi.fn())
 }));
 
 // Mock boardUtils — createBoardFromTemplate is called when ?template= is set

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,70 @@
+import { Component } from 'react';
+
+/**
+ * React error boundary that catches render errors in the subtree.
+ *
+ * Displays a friendly fallback UI instead of a blank white screen.
+ * Users can click "Try again" to reset the boundary and re-render.
+ */
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="error-boundary">
+          <div className="error-boundary-content">
+            <div className="error-boundary-icon">⚠️</div>
+            <h1 className="error-boundary-title">Something went wrong</h1>
+            <p className="error-boundary-message">
+              An unexpected error occurred. You can try again or reload the page.
+            </p>
+            {this.state.error && (
+              <details className="error-boundary-details">
+                <summary>Error details</summary>
+                <pre>{this.state.error.message || String(this.state.error)}</pre>
+              </details>
+            )}
+            <div className="error-boundary-actions">
+              <button
+                className="error-boundary-btn error-boundary-btn-primary"
+                onClick={this.handleReset}
+              >
+                Try again
+              </button>
+              <button
+                className="error-boundary-btn error-boundary-btn-secondary"
+                onClick={this.handleReload}
+              >
+                Reload page
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary.test.jsx
+++ b/src/components/ErrorBoundary.test.jsx
@@ -1,0 +1,149 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ErrorBoundary from './ErrorBoundary';
+
+// Helper component that throws on render based on shouldThrow prop
+function ThrowingComponent({ shouldThrow = false, children = null }) {
+  if (shouldThrow) {
+    throw new Error('Test error from child component');
+  }
+  return <div>{children}</div>;
+}
+
+// Helper component that can toggle error state
+let toggleErrorState = false;
+function TogglingErrorComponent() {
+  if (toggleErrorState) {
+    throw new Error('Toggled error');
+  }
+  return <div>Success content</div>;
+}
+
+describe('ErrorBoundary Component', () => {
+  beforeEach(() => {
+    // Mock console.error to suppress error output during tests
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Mock window.location.reload
+    delete window.location;
+    window.location = { reload: vi.fn() };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <div>Hello World</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Hello World')).toBeInTheDocument();
+  });
+
+  it('renders error fallback UI when child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'An unexpected error occurred. You can try again or reload the page.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('shows error message in details/summary', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    const summary = screen.getByText('Error details');
+    expect(summary).toBeInTheDocument();
+
+    const detailsElement = summary.closest('details');
+    expect(detailsElement).toBeInTheDocument();
+    expect(detailsElement).toHaveTextContent('Test error from child component');
+  });
+
+  it('"Try again" button resets boundary state and allows successful re-render', () => {
+    // Start with error state
+    toggleErrorState = true;
+    render(
+      <ErrorBoundary>
+        <TogglingErrorComponent />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+
+    // Reset error condition before trying again
+    toggleErrorState = false;
+
+    // Click "Try again" button to reset the error state
+    const tryAgainButton = screen.getByRole('button', { name: 'Try again' });
+    fireEvent.click(tryAgainButton);
+
+    // After click with error cleared, should render children successfully
+    expect(screen.getByText('Success content')).toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+  });
+
+  it('"Reload page" button calls window.location.reload', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    const reloadButton = screen.getByRole('button', { name: 'Reload page' });
+    fireEvent.click(reloadButton);
+
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  it('logs error to console.error via componentDidCatch', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error');
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'ErrorBoundary caught an error:',
+      expect.any(Error),
+      expect.any(Object)
+    );
+  });
+
+  it('renders warning icon in error fallback', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('⚠️')).toBeInTheDocument();
+  });
+
+  it('renders both action buttons in error state', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Reload page' })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/OfflineIndicator.jsx
+++ b/src/components/OfflineIndicator.jsx
@@ -1,0 +1,21 @@
+import { WifiOff } from 'react-feather';
+import { useConnectionStatus } from '../hooks/useConnectionStatus';
+
+/**
+ * Renders a subtle top-of-screen banner when the Firebase connection is lost.
+ * Automatically hides when the connection is restored.
+ */
+const OfflineIndicator = () => {
+  const { isOnline } = useConnectionStatus();
+
+  if (isOnline) return null;
+
+  return (
+    <div className="offline-indicator" role="alert" aria-live="polite">
+      <WifiOff size={14} />
+      <span>You&rsquo;re offline — changes will sync when reconnected</span>
+    </div>
+  );
+};
+
+export default OfflineIndicator;

--- a/src/components/OfflineIndicator.test.jsx
+++ b/src/components/OfflineIndicator.test.jsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useConnectionStatus } from '../hooks/useConnectionStatus';
+import OfflineIndicator from './OfflineIndicator';
+
+// Mock the useConnectionStatus hook
+vi.mock('../hooks/useConnectionStatus', () => ({
+  useConnectionStatus: vi.fn()
+}));
+
+describe('OfflineIndicator Component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null (renders nothing) when isOnline is true', () => {
+    useConnectionStatus.mockReturnValue({
+      isOnline: true
+    });
+
+    const { container } = render(<OfflineIndicator />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the offline banner when isOnline is false', () => {
+    useConnectionStatus.mockReturnValue({
+      isOnline: false
+    });
+
+    render(<OfflineIndicator />);
+
+    const offlineBanner = screen.getByRole('alert');
+    expect(offlineBanner).toBeInTheDocument();
+  });
+
+  it('banner contains the WifiOff icon area and the offline message text', () => {
+    useConnectionStatus.mockReturnValue({
+      isOnline: false
+    });
+
+    render(<OfflineIndicator />);
+
+    // Check for the message text (using HTML entity conversion)
+    const messageText = screen.getByText((content, element) => {
+      return element && element.tagName.toLowerCase() === 'span' && content.includes('offline');
+    });
+    expect(messageText).toBeInTheDocument();
+    expect(messageText.textContent).toContain('sync');
+
+    // The WifiOff icon is rendered as an SVG within the banner
+    const banner = screen.getByRole('alert');
+    const svg = banner.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('banner has role="alert" and aria-live="polite" attributes', () => {
+    useConnectionStatus.mockReturnValue({
+      isOnline: false
+    });
+
+    render(<OfflineIndicator />);
+
+    const banner = screen.getByRole('alert');
+    expect(banner).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('has className "offline-indicator"', () => {
+    useConnectionStatus.mockReturnValue({
+      isOnline: false
+    });
+
+    render(<OfflineIndicator />);
+
+    const banner = screen.getByRole('alert');
+    expect(banner).toHaveClass('offline-indicator');
+  });
+});

--- a/src/hooks/useConnectionStatus.js
+++ b/src/hooks/useConnectionStatus.js
@@ -1,0 +1,28 @@
+import { ref, onValue } from 'firebase/database';
+import { useEffect, useState } from 'react';
+import { database } from '../utils/firebase';
+
+/**
+ * Hook that monitors Firebase Realtime Database connection state.
+ *
+ * Uses the special `.info/connected` path that Firebase provides.
+ * Returns `true` when connected, `false` when disconnected.
+ * Starts as `true` to avoid a flash of the offline indicator on mount.
+ *
+ * @returns {{ isOnline: boolean }}
+ */
+export const useConnectionStatus = () => {
+  const [isOnline, setIsOnline] = useState(true);
+
+  useEffect(() => {
+    const connectedRef = ref(database, '.info/connected');
+
+    const unsubscribe = onValue(connectedRef, (snapshot) => {
+      setIsOnline(snapshot.val() === true);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  return { isOnline };
+};

--- a/src/hooks/useConnectionStatus.test.js
+++ b/src/hooks/useConnectionStatus.test.js
@@ -1,0 +1,193 @@
+import { renderHook, act } from '@testing-library/react';
+import { ref, onValue } from 'firebase/database';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useConnectionStatus } from './useConnectionStatus';
+
+// Mock Firebase modules
+vi.mock('../utils/firebase', () => ({
+  database: {}
+}));
+
+vi.mock('firebase/database', () => ({
+  ref: vi.fn(),
+  onValue: vi.fn()
+}));
+
+describe('useConnectionStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts with isOnline = true (default state)', () => {
+    const unsubscribeMock = vi.fn();
+    onValue.mockImplementation(() => unsubscribeMock);
+
+    const { result } = renderHook(() => useConnectionStatus());
+
+    expect(result.current.isOnline).toBe(true);
+  });
+
+  it('subscribes to .info/connected ref on mount', () => {
+    const unsubscribeMock = vi.fn();
+    onValue.mockImplementation(() => unsubscribeMock);
+
+    renderHook(() => useConnectionStatus());
+
+    // Verify ref was called with '.info/connected'
+    expect(ref).toHaveBeenCalledWith(expect.any(Object), '.info/connected');
+
+    // Verify onValue was called with the ref result
+    expect(onValue).toHaveBeenCalledWith(
+      ref.mock.results[0].value,
+      expect.any(Function)
+    );
+  });
+
+  it('sets isOnline to true when snapshot.val() returns true', () => {
+    const unsubscribeMock = vi.fn();
+    let capturedCallback;
+
+    onValue.mockImplementation((refArg, callback) => {
+      capturedCallback = callback;
+      return unsubscribeMock;
+    });
+
+    const { result } = renderHook(() => useConnectionStatus());
+
+    // Simulate Firebase snapshot with true value
+    act(() => {
+      capturedCallback({ val: () => true });
+    });
+
+    expect(result.current.isOnline).toBe(true);
+  });
+
+  it('sets isOnline to false when snapshot.val() returns false', () => {
+    const unsubscribeMock = vi.fn();
+    let capturedCallback;
+
+    onValue.mockImplementation((refArg, callback) => {
+      capturedCallback = callback;
+      return unsubscribeMock;
+    });
+
+    const { result } = renderHook(() => useConnectionStatus());
+
+    // Simulate Firebase snapshot with false value
+    act(() => {
+      capturedCallback({ val: () => false });
+    });
+
+    expect(result.current.isOnline).toBe(false);
+  });
+
+  it('transitions from online to offline', () => {
+    const unsubscribeMock = vi.fn();
+    let capturedCallback;
+
+    onValue.mockImplementation((refArg, callback) => {
+      capturedCallback = callback;
+      return unsubscribeMock;
+    });
+
+    const { result } = renderHook(() => useConnectionStatus());
+
+    // Start online
+    expect(result.current.isOnline).toBe(true);
+
+    // Go offline
+    act(() => {
+      capturedCallback({ val: () => false });
+    });
+
+    expect(result.current.isOnline).toBe(false);
+
+    // Go back online
+    act(() => {
+      capturedCallback({ val: () => true });
+    });
+
+    expect(result.current.isOnline).toBe(true);
+  });
+
+  it('cleans up the onValue listener on unmount', () => {
+    const unsubscribeMock = vi.fn();
+
+    onValue.mockImplementation(() => unsubscribeMock);
+
+    const { unmount } = renderHook(() => useConnectionStatus());
+
+    // Verify unsubscribe was not called yet
+    expect(unsubscribeMock).not.toHaveBeenCalled();
+
+    // Unmount the hook
+    unmount();
+
+    // Verify unsubscribe was called during cleanup
+    expect(unsubscribeMock).toHaveBeenCalled();
+  });
+
+  it('does not re-subscribe on re-render (empty dependency array)', () => {
+    const unsubscribeMock = vi.fn();
+
+    onValue.mockImplementation(() => unsubscribeMock);
+
+    const { rerender } = renderHook(() => useConnectionStatus());
+
+    // Clear mocks after initial render
+    vi.clearAllMocks();
+
+    // Re-render the hook
+    rerender();
+
+    // Verify onValue was not called again (no re-subscription)
+    expect(onValue).not.toHaveBeenCalled();
+  });
+
+  it('handles multiple rapid connection state changes', () => {
+    const unsubscribeMock = vi.fn();
+    let capturedCallback;
+
+    onValue.mockImplementation((refArg, callback) => {
+      capturedCallback = callback;
+      return unsubscribeMock;
+    });
+
+    const { result } = renderHook(() => useConnectionStatus());
+
+    // Rapid state changes
+    act(() => {
+      capturedCallback({ val: () => false });
+    });
+    expect(result.current.isOnline).toBe(false);
+
+    act(() => {
+      capturedCallback({ val: () => true });
+    });
+    expect(result.current.isOnline).toBe(true);
+
+    act(() => {
+      capturedCallback({ val: () => false });
+    });
+    expect(result.current.isOnline).toBe(false);
+
+    act(() => {
+      capturedCallback({ val: () => true });
+    });
+    expect(result.current.isOnline).toBe(true);
+  });
+
+  it('returns an object with isOnline property', () => {
+    const unsubscribeMock = vi.fn();
+    onValue.mockImplementation(() => unsubscribeMock);
+
+    const { result } = renderHook(() => useConnectionStatus());
+
+    expect(result.current).toHaveProperty('isOnline');
+    expect(typeof result.current.isOnline).toBe('boolean');
+  });
+});

--- a/src/hooks/useGroups.js
+++ b/src/hooks/useGroups.js
@@ -1,6 +1,7 @@
 import { ref, set, remove } from 'firebase/database';
 import { useCallback } from 'react';
 import { database } from '../utils/firebase';
+import { withRetry } from '../utils/firebaseRetry';
 import { generateId } from '../utils/ids';
 
 /**
@@ -110,7 +111,7 @@ export const useGroups = ({ boardId, user, columns, recordAction = null }) => {
     }
 
     // Execute all operations atomically
-    return Promise.all(promises)
+    return withRetry(() => Promise.all(promises), { operationName: 'Move card' })
       .catch(error => {
         console.error('Error moving card:', error);
         throw error; // Re-throw so caller can handle it
@@ -145,11 +146,10 @@ export const useGroups = ({ boardId, user, columns, recordAction = null }) => {
       return set(cardRef, groupId);
     });
 
-    // Create the group and update cards atomically
-    Promise.all([
+    withRetry(() => Promise.all([
       set(groupRef, groupData),
       ...cardUpdatePromises
-    ])
+    ]), { operationName: 'Create card group' })
       .then(() => {
         // Record undo after successful creation
         if (recordAction) {
@@ -199,10 +199,10 @@ export const useGroups = ({ boardId, user, columns, recordAction = null }) => {
     // Remove the group
     const groupRef = ref(database, `boards/${boardId}/columns/${columnId}/groups/${groupId}`);
 
-    Promise.all([
+    withRetry(() => Promise.all([
       ...updatePromises,
       remove(groupRef)
-    ])
+    ]), { operationName: 'Ungroup cards' })
       .then(() => {
         // Record undo after successful ungroup
         if (recordAction) {
@@ -257,7 +257,7 @@ export const useGroups = ({ boardId, user, columns, recordAction = null }) => {
       }
     });
 
-    return Promise.all(promises)
+    return withRetry(() => Promise.all(promises), { operationName: 'Remove all grouping' })
       .catch(error => {
         console.error('Error removing all grouping:', error);
         throw error;
@@ -271,7 +271,7 @@ export const useGroups = ({ boardId, user, columns, recordAction = null }) => {
     }
 
     const nameRef = ref(database, `boards/${boardId}/columns/${columnId}/groups/${groupId}/name`);
-    set(nameRef, newName)
+    withRetry(() => set(nameRef, newName), { operationName: 'Update group name' })
       .catch(error => {
         console.error('Error updating group name:', error);
       });
@@ -284,7 +284,7 @@ export const useGroups = ({ boardId, user, columns, recordAction = null }) => {
     }
 
     const expandedRef = ref(database, `boards/${boardId}/columns/${columnId}/groups/${groupId}/expanded`);
-    set(expandedRef, expanded)
+    withRetry(() => set(expandedRef, expanded), { operationName: 'Toggle group expanded' })
       .catch(error => {
         console.error('Error updating group expanded state:', error);
       });

--- a/src/hooks/useVoting.js
+++ b/src/hooks/useVoting.js
@@ -2,6 +2,7 @@ import { ref, set } from 'firebase/database';
 import { useCallback } from 'react';
 import { useNotification } from '../context/NotificationContext';
 import { database } from '../utils/firebase';
+import { withRetry } from '../utils/firebaseRetry';
 
 /**
  * Hook for voting operations across cards and groups.
@@ -104,7 +105,7 @@ export const useVoting = ({
           // Reset votes to 0 and clear all voters
           const cardRef = ref(database, `boards/${boardId}/columns/${columnId}/cards/${cardId}`);
           const updatedCard = { ...card, votes: 0, voters: {} };
-          set(cardRef, updatedCard)
+          withRetry(() => set(cardRef, updatedCard), { operationName: 'Reset card votes' })
             .catch(error => {
               console.error(`Error resetting votes for card ${cardId}:`, error);
             });
@@ -117,7 +118,7 @@ export const useVoting = ({
           // Reset group votes to 0 and clear all voters
           const groupRef = ref(database, `boards/${boardId}/columns/${columnId}/groups/${groupId}`);
           const updatedGroup = { ...group, votes: 0, voters: {} };
-          set(groupRef, updatedGroup)
+          withRetry(() => set(groupRef, updatedGroup), { operationName: 'Reset group votes' })
             .catch(error => {
               console.error(`Error resetting votes for group ${groupId}:`, error);
             });
@@ -177,10 +178,10 @@ export const useVoting = ({
     const groupVotesRef = ref(database, `boards/${boardId}/columns/${columnId}/groups/${groupId}/votes`);
     const groupVotersRef = ref(database, `boards/${boardId}/columns/${columnId}/groups/${groupId}/voters`);
 
-    Promise.all([
+    withRetry(() => Promise.all([
       set(groupVotesRef, newVotes),
       set(groupVotersRef, newVoters)
-    ]).then(() => {
+    ]), { operationName: 'Upvote group' }).then(() => {
       showNotification('Upvoted group');
     }).catch(error => {
       console.error('Error updating group votes:', error);
@@ -216,10 +217,10 @@ export const useVoting = ({
     const groupVotesRef = ref(database, `boards/${boardId}/columns/${columnId}/groups/${groupId}/votes`);
     const groupVotersRef = ref(database, `boards/${boardId}/columns/${columnId}/groups/${groupId}/voters`);
 
-    Promise.all([
+    withRetry(() => Promise.all([
       set(groupVotesRef, newVotes),
       set(groupVotersRef, newVoters)
-    ]).then(() => {
+    ]), { operationName: 'Downvote group' }).then(() => {
       showNotification('Downvoted group');
     }).catch(error => {
       console.error('Error updating group votes:', error);

--- a/src/styles/components/error-handling.css
+++ b/src/styles/components/error-handling.css
@@ -1,0 +1,131 @@
+/**
+ * Error Boundary & Offline Indicator Styles
+ */
+
+/* ---- Error Boundary Fallback ---- */
+.error-boundary {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: var(--space-xl);
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}
+
+.error-boundary-content {
+    text-align: center;
+    max-width: 480px;
+}
+
+.error-boundary-icon {
+    font-size: 3rem;
+    margin-bottom: var(--space-md);
+}
+
+.error-boundary-title {
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+    margin: 0 0 var(--space-sm);
+    color: var(--text-color);
+}
+
+.error-boundary-message {
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+    margin: 0 0 var(--space-lg);
+    line-height: 1.5;
+}
+
+.error-boundary-details {
+    text-align: left;
+    margin-bottom: var(--space-lg);
+    padding: var(--space-sm);
+    background-color: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-xs);
+}
+
+.error-boundary-details summary {
+    cursor: pointer;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    margin-bottom: var(--space-xs);
+}
+
+.error-boundary-details pre {
+    margin: 0;
+    padding: var(--space-xs);
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--danger);
+    font-family: monospace;
+    font-size: var(--font-size-xs);
+}
+
+.error-boundary-actions {
+    display: flex;
+    gap: var(--space-sm);
+    justify-content: center;
+}
+
+.error-boundary-btn {
+    padding: var(--space-xs) var(--space-md);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color var(--transition-speed) var(--transition-ease),
+                border-color var(--transition-speed) var(--transition-ease);
+    border: 1px solid transparent;
+}
+
+.error-boundary-btn-primary {
+    background-color: var(--accent);
+    color: var(--text-on-accent);
+}
+
+.error-boundary-btn-primary:hover {
+    background-color: var(--accent-hover);
+}
+
+.error-boundary-btn-secondary {
+    background-color: transparent;
+    color: var(--text-muted);
+    border-color: var(--border-color);
+}
+
+.error-boundary-btn-secondary:hover {
+    background-color: var(--hover-bg);
+    color: var(--text-color);
+}
+
+/* ---- Offline Indicator ---- */
+.offline-indicator {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-xs);
+    padding: var(--space-xxs) var(--space-sm);
+    background-color: var(--warning-color);
+    color: #000;
+    font-size: var(--font-size-xs);
+    font-weight: 500;
+    animation: slideDown 0.3s ease;
+}
+
+@keyframes slideDown {
+    from {
+        transform: translateY(-100%);
+    }
+    to {
+        transform: translateY(0);
+    }
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -23,6 +23,7 @@
 @import 'components/timer.css';
 @import 'components/dashboard.css';
 @import 'components/search.css';
+@import 'components/error-handling.css';
 
 /* Utility classes and notifications */
 .notification {

--- a/src/utils/firebaseRetry.js
+++ b/src/utils/firebaseRetry.js
@@ -1,0 +1,85 @@
+/**
+ * Retry utility for transient Firebase write failures.
+ *
+ * Wraps a Firebase operation (set/remove) with exponential backoff retry logic.
+ * Only retries on transient errors (network, unavailable); permission and
+ * validation errors fail immediately.
+ */
+
+const TRANSIENT_ERROR_CODES = new Set([
+  'NETWORK_ERROR',
+  'TIMEOUT',
+  'UNAVAILABLE',
+  'network-request-failed',
+]);
+
+/**
+ * Returns true when the error looks transient (worth retrying).
+ * @param {Error} error
+ * @returns {boolean}
+ */
+function isTransientError(error) {
+  if (!error) return false;
+
+  const code = error.code || '';
+  if (TRANSIENT_ERROR_CODES.has(code)) return true;
+
+  const message = (error.message || '').toLowerCase();
+  return (
+    message.includes('network') ||
+    message.includes('timeout') ||
+    message.includes('unavailable') ||
+    message.includes('failed to fetch') ||
+    message.includes('client is offline')
+  );
+}
+
+/**
+ * Execute a Firebase operation with automatic retry on transient failures.
+ *
+ * @param {() => Promise} operation - The Firebase write to perform (e.g., () => set(ref, data))
+ * @param {Object} [options]
+ * @param {number} [options.maxRetries=3] - Maximum number of retry attempts
+ * @param {number} [options.baseDelay=500] - Base delay in ms (doubled each retry)
+ * @param {string} [options.operationName='Firebase operation'] - For logging
+ * @returns {Promise} Resolves when the operation succeeds, rejects after all retries exhausted
+ */
+export async function withRetry(operation, options = {}) {
+  const {
+    maxRetries = 3,
+    baseDelay = 500,
+    operationName = 'Firebase operation',
+  } = options;
+
+  let lastError;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+
+      // Don't retry non-transient errors (permission denied, invalid data, etc.)
+      if (!isTransientError(error)) {
+        throw error;
+      }
+
+      // If we've exhausted retries, throw
+      if (attempt >= maxRetries) {
+        console.error(
+          `${operationName} failed after ${maxRetries + 1} attempts:`,
+          error
+        );
+        throw error;
+      }
+
+      // Exponential backoff with jitter
+      const delay = baseDelay * Math.pow(2, attempt) + Math.random() * 100;
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}
+
+export { isTransientError };

--- a/src/utils/firebaseRetry.test.js
+++ b/src/utils/firebaseRetry.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { withRetry, isTransientError } from './firebaseRetry';
+
+describe('isTransientError', () => {
+  it('returns false for null/undefined', () => {
+    expect(isTransientError(null)).toBe(false);
+    expect(isTransientError(undefined)).toBe(false);
+  });
+
+  it('returns true for known transient error codes', () => {
+    expect(isTransientError({ code: 'NETWORK_ERROR' })).toBe(true);
+    expect(isTransientError({ code: 'TIMEOUT' })).toBe(true);
+    expect(isTransientError({ code: 'UNAVAILABLE' })).toBe(true);
+    expect(isTransientError({ code: 'network-request-failed' })).toBe(true);
+  });
+
+  it('returns true for transient error messages', () => {
+    expect(isTransientError({ message: 'Network error occurred' })).toBe(true);
+    expect(isTransientError({ message: 'Request timeout' })).toBe(true);
+    expect(isTransientError({ message: 'Service unavailable' })).toBe(true);
+    expect(isTransientError({ message: 'Failed to fetch' })).toBe(true);
+    expect(isTransientError({ message: 'Client is offline' })).toBe(true);
+  });
+
+  it('returns false for non-transient errors', () => {
+    expect(isTransientError({ code: 'PERMISSION_DENIED' })).toBe(false);
+    expect(isTransientError({ message: 'Permission denied' })).toBe(false);
+    expect(isTransientError({ code: 'INVALID_ARGUMENT' })).toBe(false);
+    expect(isTransientError(new Error('Something else'))).toBe(false);
+  });
+});
+
+describe('withRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // Helper to advance through retries (setTimeout + jitter)
+  async function flushRetries() {
+    // Each retry uses setTimeout; advance generously to cover backoff + jitter
+    await vi.advanceTimersByTimeAsync(10000);
+  }
+
+  it('resolves on first attempt when operation succeeds', async () => {
+    const op = vi.fn().mockResolvedValue('ok');
+    const result = await withRetry(op);
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on transient error and resolves when subsequent attempt succeeds', async () => {
+    const transientError = new Error('Network error');
+    const op = vi.fn()
+      .mockRejectedValueOnce(transientError)
+      .mockResolvedValueOnce('recovered');
+
+    const promise = withRetry(op, { baseDelay: 100 });
+
+    // First attempt fails immediately, wait for retry delay
+    await flushRetries();
+
+    const result = await promise;
+    expect(result).toBe('recovered');
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws immediately on non-transient error without retrying', async () => {
+    const permError = { code: 'PERMISSION_DENIED', message: 'Denied' };
+    const op = vi.fn().mockRejectedValue(permError);
+
+    await expect(withRetry(op)).rejects.toEqual(permError);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('exhausts all retries and throws after maxRetries transient failures', async () => {
+    const transientError = new Error('Client is offline');
+    const op = vi.fn().mockRejectedValue(transientError);
+
+    const promise = withRetry(op, { maxRetries: 2, baseDelay: 50 }).catch(e => e);
+
+    // Flush through all retry delays
+    await flushRetries();
+
+    const result = await promise;
+    expect(result).toBe(transientError);
+    // 1 initial + 2 retries = 3
+    expect(op).toHaveBeenCalledTimes(3);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('respects custom maxRetries option', async () => {
+    const transientError = new Error('Network error');
+    const op = vi.fn().mockRejectedValue(transientError);
+
+    const promise = withRetry(op, { maxRetries: 1, baseDelay: 50 }).catch(e => e);
+    await flushRetries();
+
+    const result = await promise;
+    expect(result).toBe(transientError);
+    expect(op).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+  });
+
+  it('logs operationName on final failure', async () => {
+    const transientError = new Error('Unavailable');
+    const op = vi.fn().mockRejectedValue(transientError);
+
+    const promise = withRetry(op, { maxRetries: 0, operationName: 'Test op' }).catch(e => e);
+    await flushRetries();
+
+    const result = await promise;
+    expect(result).toBe(transientError);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Test op'),
+      transientError
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **ErrorBoundary** component wraps the app tree to catch render errors gracefully, displaying a friendly fallback UI with a reload button
- **OfflineIndicator** shows a yellow warning banner when the Firebase Realtime Database connection is lost, using a new `useConnectionStatus` hook that monitors `.info/connected`
- **`withRetry` utility** (`src/utils/firebaseRetry.js`) adds exponential backoff with jitter for transient Firebase write failures — configurable max retries, base delay, and operation naming for error messages
- All Firebase `set()`/`remove()` calls in `useGroups` (6 functions) and `useVoting` are now wrapped with `withRetry`
- 32 new tests across 4 test files, all passing. Full suite: 971 tests ✅

Closes #67