### PR TITLE
Polish board view UI: declutter header and improve visual hierarchy

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -148,8 +148,6 @@ function Board({ onGoHome }) {
             boardTitle={boardTitle}
             handleBoardTitleChange={handleBoardTitleChange}
             handleBoardTitleBlur={handleBoardTitleBlur}
-            copyShareUrl={copyShareUrl}
-            handleExportBoard={handleExportBoard}
             onGoHome={onGoHome}
             onSearchOpen={searchFilter.openSearch}
             isSearchOpen={searchFilter.isOpen}
@@ -159,6 +157,8 @@ function Board({ onGoHome }) {
               startHealthCheckPhase();
               showNotification('Health check started');
             }}
+            copyShareUrl={copyShareUrl}
+            handleExportBoard={handleExportBoard}
             sortByVotes={sortByVotes}
             setSortByVotes={setSortByVotes}
             votingEnabled={votingEnabled}

--- a/src/components/Board.test.jsx
+++ b/src/components/Board.test.jsx
@@ -140,9 +140,9 @@ describe('Board Component', () => {
     const boardTitleInput = screen.getByDisplayValue('Test Board');
     expect(boardTitleInput).toBeInTheDocument();
 
-    // Check if Share button exists
-    const shareButton = screen.getByTitle('Copy Share URL');
-    expect(shareButton).toBeInTheDocument();
+    // Check if settings button exists
+    const settingsButton = screen.getByTitle('Board settings and preferences');
+    expect(settingsButton).toBeInTheDocument();
 
     // Check if columns are rendered
     expect(screen.getByText('To Do')).toBeInTheDocument();
@@ -202,7 +202,11 @@ describe('Board Component', () => {
       </DndProvider>
     );
 
-    const copyButton = screen.getByTitle('Copy Share URL');
+    // Open settings dropdown first
+    const settingsButton = screen.getByTitle('Board settings and preferences');
+    fireEvent.click(settingsButton);
+
+    const copyButton = screen.getByText('Share Board');
     fireEvent.click(copyButton);
 
     const expectedUrl = 'https://example.com/?board=test-board-123';

--- a/src/components/BoardHeader.jsx
+++ b/src/components/BoardHeader.jsx
@@ -1,9 +1,6 @@
-import { Home, Link, FileText, Search } from 'react-feather';
+import { Home, Search } from 'react-feather';
 import { DEFAULT_BOARD_TITLE } from '../context/BoardContext';
-import TotalVoteCounter from './TotalVoteCounter';
 import UserCounter from './UserCounter';
-import VoteCounter from './VoteCounter';
-
 /**
  * Board header with title input, user/vote counters, and share/export buttons.
  *
@@ -11,11 +8,8 @@ import VoteCounter from './VoteCounter';
  * @param {string} props.boardTitle - Current board title
  * @param {Function} props.handleBoardTitleChange - Called on title input change
  * @param {Function} props.handleBoardTitleBlur - Called on title input blur (persists to Firebase)
- * @param {Function} props.copyShareUrl - Copies the board share URL to clipboard
- * @param {Function} props.handleExportBoard - Opens the export board modal
- * @param {Function} props.onGoHome - Navigates back to dashboard
  */
-const BoardHeader = ({ boardTitle, handleBoardTitleChange, handleBoardTitleBlur, copyShareUrl, handleExportBoard, onGoHome, onSearchOpen, isSearchOpen }) => (
+const BoardHeader = ({ boardTitle, handleBoardTitleChange, handleBoardTitleBlur, onGoHome, onSearchOpen, isSearchOpen }) => (
   <div className="board-title-container">
     {onGoHome && (
       <button
@@ -49,25 +43,6 @@ const BoardHeader = ({ boardTitle, handleBoardTitleChange, handleBoardTitleBlur,
     )}
     <div className="action-buttons">
       <UserCounter />
-      <VoteCounter />
-      <TotalVoteCounter />
-      <button
-        id="copy-share-url"
-        className="btn secondary-btn btn-with-icon"
-        title="Copy Share URL"
-        onClick={copyShareUrl}
-      >
-        <Link size={16} />
-        Share
-      </button>
-      <button
-        id="export-board"
-        className="btn secondary-btn btn-with-icon"
-        onClick={handleExportBoard}
-      >
-        <FileText size={16} />
-        Export
-      </button>
     </div>
 
   </div>

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { ArrowDown, ThumbsUp, Settings, Sun, Moon, Heart } from 'react-feather';
+import { ArrowDown, ThumbsUp, Settings, Sun, Moon, Heart, Link, FileText } from 'react-feather';
 import { useNotification } from '../context/NotificationContext';
 import { useOnClickOutside } from '../hooks/useOnClickOutside';
 import Timer from './Timer';
@@ -28,6 +28,8 @@ import Timer from './Timer';
  */
 const SettingsPanel = ({
   handleStartHealthCheck,
+  copyShareUrl,
+  handleExportBoard,
   sortByVotes,
   setSortByVotes,
   votingEnabled,
@@ -55,14 +57,6 @@ const SettingsPanel = ({
 
   return (
     <div className="action-buttons">
-      <button
-        id="start-health-check"
-        className="btn btn-with-icon"
-        onClick={handleStartHealthCheck}
-      >
-        <Heart size={16} />
-        Health Check
-      </button>
       <Timer />
       <div className="sort-dropdown-container" ref={dropdownRef}>
         <button
@@ -79,6 +73,39 @@ const SettingsPanel = ({
 
         {sortDropdownOpen && (
           <div className="sort-dropdown-menu">
+            <div className="settings-section">
+              <button
+                className="sort-option"
+                onClick={() => {
+                  copyShareUrl();
+                  setSortDropdownOpen(false);
+                }}
+              >
+                <Link size={14} />
+                Share Board
+              </button>
+              <button
+                className="sort-option"
+                onClick={() => {
+                  handleExportBoard();
+                  setSortDropdownOpen(false);
+                }}
+              >
+                <FileText size={14} />
+                Export Board
+              </button>
+              <button
+                className="sort-option"
+                onClick={() => {
+                  handleStartHealthCheck();
+                  setSortDropdownOpen(false);
+                }}
+              >
+                <Heart size={14} />
+                Start Health Check
+              </button>
+            </div>
+            <div className="settings-divider"></div>
             <div className="settings-section">
               <h4 className="settings-section-title">Sort Cards</h4>
               <button

--- a/src/styles/components/cards.css
+++ b/src/styles/components/cards.css
@@ -425,13 +425,12 @@
     height: 120px;
     margin: 20px 0;
     padding: var(--space-sm);
-    border: 2px dashed var(--border-color);
+    border: 1px dashed rgba(139, 148, 158, 0.2);
     border-radius: var(--radius-md);
     color: var(--text-muted);
     font-style: italic;
-    background-color: rgba(255, 255, 255, 0.02);
+    background-color: transparent;
 }
-
 .empty-column-placeholder span:first-child {
     font-weight: 500;
     margin-bottom: var(--space-xs);

--- a/src/styles/components/columns.css
+++ b/src/styles/components/columns.css
@@ -123,13 +123,15 @@ main {
 .column-header {
     padding: var(--space-md);
     border-bottom: 1px solid var(--border-color);
+    background-color: var(--hover-bg);
     display: flex;
     justify-content: space-between;
     align-items: center;
+    border-top-left-radius: var(--radius-md);
+    border-top-right-radius: var(--radius-md);
 }
-
 .column-title {
-    font-weight: 600;
+    font-weight: 700;
     margin: 0;
     font-size: var(--font-size-base);
     padding: var(--space-xxs) var(--space-xs);
@@ -187,12 +189,13 @@ main {
 }
 
 .column-content:empty::before {
-    content: "Add a card to get started";
+    content: "No cards yet";
     position: absolute;
-    top: 50%;
+    top: 40%;
     left: 50%;
     transform: translate(-50%, -50%);
     color: var(--text-muted);
+    opacity: 0.5;
     font-style: italic;
     text-align: center;
     display: flex;
@@ -200,7 +203,6 @@ main {
     align-items: center;
     width: 80%;
 }
-
 .column-content.drag-over {
     background-color: var(--drag-over);
 }

--- a/src/styles/components/header.css
+++ b/src/styles/components/header.css
@@ -10,6 +10,9 @@ header {
     padding: var(--space-md);
     background: var(--card-bg);
     border-bottom: 1px solid var(--border-color);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+    position: relative;
+    z-index: 10;
 }
 
 .header-content {
@@ -125,16 +128,12 @@ h1 {
     display: inline-block;
 }
 
-/* Settings toggle button (icon-only) */
+/* Settings toggle button */
 .settings-toggle-btn {
-    background-color: var(--accent);
-    color: white;
-    border: 1px solid transparent;
     transition: all var(--transition-speed) var(--transition-ease);
 }
 
 .settings-toggle-btn:hover {
-    background-color: var(--accent-dark);
     box-shadow: var(--shadow-sm);
 }
 
@@ -272,12 +271,12 @@ h1 {
 
 /* When dropdown is open, add a subtle indicator */
 .sort-dropdown-container:has(.sort-dropdown-menu) .settings-toggle-btn {
-    box-shadow: 0 0 0 2px var(--accent-transparent);
+    background-color: var(--hover-bg);
 }
 
 /* Fallback for browsers that don't support :has() */
 .settings-toggle-btn[aria-expanded="true"] {
-    box-shadow: 0 0 0 2px var(--accent-transparent);
+    background-color: var(--hover-bg);
 }
 
 /* Mobile responsive adjustments for header elements */
@@ -330,11 +329,11 @@ h1 {
 .user-counter {
     display: flex;
     align-items: center;
-    gap: 6px;
-    padding: 6px 6px 6px 12px;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
+    gap: 4px;
+    padding: 6px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
     color: var(--text-secondary);
     font-size: var(--font-size-sm);
     font-weight: 500;
@@ -343,8 +342,7 @@ h1 {
 }
 
 .user-counter:hover {
-    background: var(--bg-tertiary);
-    border-color: var(--border-hover);
+    background: var(--hover-bg);
 }
 
 .user-count {

--- a/src/styles/components/search.css
+++ b/src/styles/components/search.css
@@ -139,7 +139,7 @@
 }
 
 .search-trigger-btn:hover {
-    color: var(--text-color);
+    color: var(--accent);
     background: var(--hover-bg);
 }
 

--- a/src/styles/components/variables.css
+++ b/src/styles/components/variables.css
@@ -23,7 +23,7 @@
     --card-bg: #161b22;
     --hover-bg: #1f2428;
     --border-color: #30363d;
-    --column-bg: #161b22;
+    --column-bg: #111820;
     --drag-over: var(--accent-transparent-light);
     --primary-color: #58a6ff;
     --primary-color-rgb: 88, 166, 255;
@@ -64,7 +64,7 @@
     --card-highlight: rgba(88, 166, 255, 0.6);
 
     /* Shadows */
-    --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+    --card-shadow: 0 4px 6px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
     --modal-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
     --notification-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     
@@ -118,10 +118,10 @@
     --card-bg: #ffffff;
     --hover-bg: #f3f4f6;
     --border-color: #d0d7de;
-    --column-bg: #ffffff;
+    --column-bg: #ebedf0;
     
     /* Shadows for light theme */
-    --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    --card-shadow: 0 2px 6px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.05);
     --modal-shadow: 0 8px 24px rgba(140, 149, 159, 0.2);
     --notification-shadow: 0 2px 8px rgba(140, 149, 159, 0.15);
     


### PR DESCRIPTION
## Summary

- **Decluttered the board header** — moved Share Board, Export Board, and Start Health Check into the Settings dropdown, leaving only Home, board title, search, and user counter in the header bar
- **Improved visual depth hierarchy** — tuned column background colors and card shadows in both dark and light themes so the layering reads clearly as background → columns → cards → header
- **Refined styling details** — header gets a subtle box-shadow, column headers have rounded backgrounds with bold titles, settings button is toned down, and empty column placeholders are softened

## Changes (9 files, +74/-69)

| File | What changed |
|------|-------------|
| `BoardHeader.jsx` | Removed VoteCounter, TotalVoteCounter, Share, Export buttons |
| `SettingsPanel.jsx` | Added Share Board, Export Board, Start Health Check as top items with divider |
| `Board.jsx` | Wired `copyShareUrl` and `handleExportBoard` to SettingsPanel instead of BoardHeader |
| `Board.test.jsx` | Updated to open settings dropdown before asserting Share Board action |
| `header.css` | Header box-shadow, toned-down settings button, compact UserCounter |
| `variables.css` | Adjusted `--column-bg` and `--card-shadow` for both dark and light themes |
| `columns.css` | Column header background/radius, bold titles, subtle empty state text |
| `cards.css` | Softened empty-column-placeholder border |
| `search.css` | Search trigger hover uses accent color |

## Header before → after

**Before:** `[Home] [Title] [🔍] [👤 1] [Vote Counter] [Total Votes] [Share] [Export] [⏱ Timer] [⚙️ Settings] [☀️/🌙]`

**After:** `[Home] [Title] [🔍] [👤 1] ........spacer........ [⏱ Timer] [⚙️ Settings] [☀️/🌙]`

## Verification

- ✅ `npm run lint:fix` — clean
- ✅ `npm test` — all 939 tests pass
- ✅ `npm run build` — succeeds
- ✅ Visually reviewed in both dark and light mode