### PR TITLE
Add env var support, accessibility improvements, and performance memoization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Firebase configuration
+# Copy this file to .env and fill in your Firebase project values.
+# The app falls back to the default project values if these are not set.
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_DATABASE_URL=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -130,6 +130,11 @@ function AppContent() {
 
   return (
     <div className="App" data-testid="app-container">
+      {activeBoardId && (
+        <a href="#board-content" className="skip-to-content">
+          Skip to board content
+        </a>
+      )}
       {activeBoardId ? (
         <BoardGate boardId={activeBoardId} onGoHome={handleGoHome} />
       ) : (
@@ -137,7 +142,7 @@ function AppContent() {
       )}
 
       {/* Success Notification */}
-      <div id="notification" className={`notification ${notification.show ? 'show' : ''}`}>
+      <div id="notification" className={`notification ${notification.show ? 'show' : ''}`} role="status" aria-live="polite">
         <span id="notification-message">{notification.message}</span>
         {notification.actionLabel && (
           <button

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -203,7 +203,7 @@ function Board({ onGoHome }) {
       )}
 
 
-      <main>
+      <main id="board-content">
         {workflowPhase === WORKFLOW_PHASES.HEALTH_CHECK ? (
           <HealthCheckVoting />
         ) : retrospectiveMode && workflowPhase === WORKFLOW_PHASES.RESULTS ? (

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { memo, useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { MessageSquare } from 'react-feather';
 import { useBoardContext } from '../context/BoardContext';
@@ -439,4 +439,4 @@ function Card({
   );
 }
 
-export default Card;
+export default memo(Card);

--- a/src/components/CardGroup.jsx
+++ b/src/components/CardGroup.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { memo, useState, useRef } from 'react';
 import { useDrop } from 'react-dnd';
 import { ChevronDown, ChevronRight, Layers, Edit2, MessageSquare } from 'react-feather';
 import { useBoardContext } from '../context/BoardContext';
@@ -408,4 +408,4 @@ function CardGroup({
   );
 }
 
-export default CardGroup;
+export default memo(CardGroup);

--- a/src/components/CardGroup.test.jsx
+++ b/src/components/CardGroup.test.jsx
@@ -479,7 +479,7 @@ describe('CardGroup Component', () => {
       isCommentAuthor: vi.fn(() => true)
     });
 
-    rerender(<CardGroup {...mockProps} groupData={groupWithComments} />);
+    rerender(<CardGroup {...mockProps} groupData={{...groupWithComments}} />);
 
     // Comments section should now be visible
     expect(screen.getByText('Comments')).toBeInTheDocument();

--- a/src/components/Column.jsx
+++ b/src/components/Column.jsx
@@ -1,9 +1,10 @@
 import { ref, set, remove } from 'firebase/database';
-import { useState, useRef, useEffect } from 'react';
+import { memo, useState, useRef, useEffect } from 'react';
 import { useDrop } from 'react-dnd';
 import { ChevronLeft, ChevronRight, Trash2, Plus } from 'react-feather';
 import { useBoardContext } from '../context/BoardContext';
 import { useNotification } from '../context/NotificationContext';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { addCard } from '../utils/boardUtils';
 import { database } from '../utils/firebase';
 import { isGroupingAllowed, isCardCreationAllowed } from '../utils/workflowUtils';
@@ -31,6 +32,16 @@ function Column({ columnId, columnData, sortByVotes, collapsed, onToggleCollapse
   const [newGroupName, setNewGroupName] = useState('');
   const [draggedCardForGrouping, setDraggedCardForGrouping] = useState(null);
   const columnRef = useRef(null);
+  const groupModalRef = useRef(null);
+
+  // Cancel group creation
+  const cancelCreateGroup = () => {
+    setShowGroupModal(false);
+    setNewGroupName('');
+    setDraggedCardForGrouping(null);
+  };
+
+  useFocusTrap(groupModalRef, showGroupModal, { onClose: cancelCreateGroup });
 
   // Update local title when columnData changes (from Firebase)
   useEffect(() => {
@@ -299,12 +310,6 @@ function Column({ columnId, columnData, sortByVotes, collapsed, onToggleCollapse
     setDraggedCardForGrouping(null);
   };
 
-  // Cancel group creation
-  const cancelCreateGroup = () => {
-    setShowGroupModal(false);
-    setNewGroupName('');
-    setDraggedCardForGrouping(null);
-  };
 
   // Count total cards in this column (including grouped cards)
   const getCardCount = () => {
@@ -452,7 +457,7 @@ function Column({ columnId, columnData, sortByVotes, collapsed, onToggleCollapse
         {/* Group creation modal */}
         {showGroupModal && (
           <div className="group-modal-overlay" onClick={cancelCreateGroup} role="presentation">
-            <div className="group-modal" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true" aria-labelledby="create-group-title">
+            <div ref={groupModalRef} className="group-modal" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true" aria-labelledby="create-group-title">
               <h3 id="create-group-title">Create Card Group</h3>
               <p>Creating a group with 2 cards</p>
               <input
@@ -488,4 +493,4 @@ function Column({ columnId, columnData, sortByVotes, collapsed, onToggleCollapse
   );
 }
 
-export default Column;
+export default memo(Column);

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -240,7 +240,7 @@ function Dashboard({ onOpenBoard, darkMode, onToggleDarkMode }) {
                   onClick={() => handleOpenBoard(board.id)}
                   role="button"
                   tabIndex={0}
-                  onKeyDown={e => e.key === 'Enter' && handleOpenBoard(board.id)}
+                  onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleOpenBoard(board.id); } }}
                 >
                   <div className="dashboard-board-info">
                     <h3 className="dashboard-board-title">{board.title || 'Untitled Board'}</h3>
@@ -305,7 +305,7 @@ function Dashboard({ onOpenBoard, darkMode, onToggleDarkMode }) {
                   onClick={() => handleOpenBoard(board.id)}
                   role="button"
                   tabIndex={0}
-                  onKeyDown={e => e.key === 'Enter' && handleOpenBoard(board.id)}
+                  onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleOpenBoard(board.id); } }}
                 >
                   <div className="dashboard-board-info">
                     <h3 className="dashboard-board-title">{board.title || 'Untitled Board'}</h3>

--- a/src/components/modals/ExportBoardModal.jsx
+++ b/src/components/modals/ExportBoardModal.jsx
@@ -1,13 +1,16 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Clipboard } from 'react-feather';
 import { useBoardContext, DEFAULT_BOARD_TITLE } from '../../context/BoardContext';
 import { useNotification } from '../../context/NotificationContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 const ExportBoardModal = ({ isOpen, onClose }) => {
   const [format, setFormat] = useState('markdown');
   const [exportedContent, setExportedContent] = useState('');
   const { boardTitle, columns } = useBoardContext();
   const { showNotification } = useNotification();
+  const modalRef = useRef(null);
+  useFocusTrap(modalRef, isOpen, { onClose });
 
   /**
    * Get a normalized structure of the board data for export
@@ -418,7 +421,7 @@ const ExportBoardModal = ({ isOpen, onClose }) => {
 
   return (
     <div className="modal-overlay" role="presentation">
-      <div className="modal-container" role="dialog" aria-modal="true" aria-labelledby="export-board-title">
+      <div ref={modalRef} className="modal-container" role="dialog" aria-modal="true" aria-labelledby="export-board-title">
         <div className="modal-header">
           <h2 id="export-board-title">Export Board</h2>
           <button className="close-button" onClick={onClose} aria-label="Close">&times;</button>

--- a/src/components/modals/NewBoardTemplateModal.jsx
+++ b/src/components/modals/NewBoardTemplateModal.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import BOARD_TEMPLATES from '../../data/boardTemplates';
 import '../../styles/components/modals.css';
 import '../../styles/components/template-select.css';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 /**
  * Safely highlights matching text by splitting into segments and wrapping
@@ -40,7 +41,9 @@ const NewBoardTemplateModal = ({ isOpen, onClose, onSelectTemplate }) => {
   const [selectedTemplate, setSelectedTemplate] = useState('default');
   const [searchQuery, setSearchQuery] = useState('');
   const [filteredTemplates, setFilteredTemplates] = useState(BOARD_TEMPLATES);
+  const modalRef = useRef(null);
 
+  useFocusTrap(modalRef, isOpen, { onClose });
   // Filter templates based on search query
   useEffect(() => {
     if (!searchQuery.trim()) {
@@ -130,7 +133,7 @@ const NewBoardTemplateModal = ({ isOpen, onClose, onSelectTemplate }) => {
 
   return (
     <div className="modal-overlay" role="presentation">
-      <div className="modal-container template-modal" role="dialog" aria-modal="true" aria-labelledby="template-modal-title">
+      <div ref={modalRef} className="modal-container template-modal" role="dialog" aria-modal="true" aria-labelledby="template-modal-title">
         <div className="modal-header">
           <h2 id="template-modal-title">Choose a Board Template</h2>
           <button className="close-button" onClick={onClose} aria-label="Close">&times;</button>

--- a/src/components/modals/VoteLimitModal.jsx
+++ b/src/components/modals/VoteLimitModal.jsx
@@ -1,8 +1,11 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import '../../styles/components/modals.css';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 const VoteLimitModal = ({ isOpen, onClose, onConfirm, currentLimit = 3 }) => {
   const [votesPerUser, setVotesPerUser] = useState(currentLimit);
+  const modalRef = useRef(null);
+  useFocusTrap(modalRef, isOpen, { onClose });
 
   if (!isOpen) return null;
 
@@ -20,7 +23,7 @@ const VoteLimitModal = ({ isOpen, onClose, onConfirm, currentLimit = 3 }) => {
 
   return (
     <div className="modal-overlay" onClick={onClose} role="presentation">
-      <div className="modal-container" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true" aria-labelledby="vote-limit-title">
+      <div ref={modalRef} className="modal-container" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true" aria-labelledby="vote-limit-title">
         <div className="modal-header">
           <h2 id="vote-limit-title">Set Vote Limit</h2>
           <button className="close-button" onClick={onClose} aria-label="Close">&times;</button>

--- a/src/context/BoardContext.jsx
+++ b/src/context/BoardContext.jsx
@@ -1,5 +1,5 @@
 import { ref, onValue, off, set } from 'firebase/database';
-import { createContext, useContext, useState, useEffect } from 'react';
+import { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import { useBoardSettings } from '../hooks/useBoardSettings';
 import { useGroups } from '../hooks/useGroups';
 import { useHealthCheck, HEALTH_CHECK_QUESTIONS } from '../hooks/useHealthCheck';
@@ -211,93 +211,6 @@ export const BoardProvider = ({ children, initialBoardId = null }) => {
     canUndo, canRedo, pastCount, futureCount
   } = useUndoRedo({ boardId, showNotification });
 
-  // Create a new board with specified template columns, title, and optional settings overrides
-  const createNewBoard = (templateColumns = null, boardTitle = DEFAULT_BOARD_TITLE, settingsOverride = null) => {
-    if (!user) {
-      return null;
-    }
-
-    const newBoardId = generateId();
-    const newBoardRef = ref(database, `boards/${newBoardId}`);
-
-    // Default columns if no template specified
-    const columnsToCreate = templateColumns || ['To Do', 'In Progress', 'Done'];
-
-    // Build columns object with ordered prefixes
-    const columnsObj = {};
-
-    // Using alphabet prefixes to ensure correct ordering
-    const alphabet = 'abcdefghijklmnopqrstuvwxyz';
-
-    columnsToCreate.forEach((columnTitle, index) => {
-      // Use alphabet prefixes up to 26 columns, then fallback to numeric prefixes
-      const prefix = index < 26 ? alphabet[index] : `col${index}`;
-      columnsObj[`${prefix}_${generateId()}`] = {
-        title: columnTitle,
-        cards: {}
-      };
-    });
-
-    // Only allow a safe subset of settings to be overridden on creation
-  const allowedOverrideKeys = ['votingEnabled', 'downvotingEnabled', 'multipleVotesAllowed', 'votesPerUser', 'retrospectiveMode', 'sortByVotes'];
-    const sanitizedOverrides = {};
-    if (settingsOverride && typeof settingsOverride === 'object') {
-      allowedOverrideKeys.forEach(k => {
-        if (settingsOverride[k] !== undefined) {
-          sanitizedOverrides[k] = settingsOverride[k];
-        }
-      });
-    }
-
-    const initialData = {
-      title: boardTitle,
-      created: Date.now(),
-      owner: user.uid,
-      columns: columnsObj,
-      settings: {
-        votingEnabled: true, // Default to enabled for new boards
-        downvotingEnabled: true, // Default to enabled for new boards
-        multipleVotesAllowed: false, // Default to not allowing multiple votes
-  sortByVotes: false, // Default to chronological
-        retrospectiveMode: false, // Default to disabled (cards are visible)
-        workflowPhase: WORKFLOW_PHASES.CREATION, // Default to creation phase
-        resultsViewIndex: 0, // Default to first result
-        // Apply any overrides parsed from URL (validated/whitelisted)
-        ...sanitizedOverrides
-      }
-    };
-
-    set(newBoardRef, initialData)
-      .then(() => {
-        setBoardId(newBoardId);
-        setBoardTitle(DEFAULT_BOARD_TITLE);
-      })
-      .catch(error => {
-        console.error('Error creating board:', error);
-      });
-
-    return newBoardId;
-  };
-
-  // Open an existing board
-  const openExistingBoard = boardIdToOpen => {
-    setBoardId(boardIdToOpen);
-  };
-
-  // Update board title
-  const updateBoardTitle = newTitle => {
-    // Optimistically update the local state first for better UI responsiveness
-    setBoardTitle(newTitle);
-
-    if (boardId && user) {
-      const titleRef = ref(database, `boards/${boardId}/title`);
-      set(titleRef, newTitle)
-        .catch(error => {
-          console.error('Error updating board title:', error);
-        });
-    }
-  };
-
   // Board settings hook
   const {
     updateBoardSettings,
@@ -365,122 +278,187 @@ export const BoardProvider = ({ children, initialBoardId = null }) => {
     boardId, user, timerData, setTimerData, workflowPhase
   });
 
-  // Update dark mode preference
-  const updateDarkMode = enabled => {
-    if (user) {
-      const userPrefsRef = ref(database, `users/${user.uid}/preferences`);
-      set(userPrefsRef, { darkMode: enabled })
+  // Context value
+  const value = useMemo(() => {
+    // Create a new board with specified template columns, title, and optional settings overrides
+    const createNewBoard = (templateColumns = null, newBoardTitle = DEFAULT_BOARD_TITLE, settingsOverride = null) => {
+      if (!user) {
+        return null;
+      }
+
+      const newBoardId = generateId();
+      const newBoardRef = ref(database, `boards/${newBoardId}`);
+
+      // Default columns if no template specified
+      const columnsToCreate = templateColumns || ['To Do', 'In Progress', 'Done'];
+
+      // Build columns object with ordered prefixes
+      const columnsObj = {};
+
+      // Using alphabet prefixes to ensure correct ordering
+      const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+
+      columnsToCreate.forEach((columnTitle, index) => {
+        // Use alphabet prefixes up to 26 columns, then fallback to numeric prefixes
+        const prefix = index < 26 ? alphabet[index] : `col${index}`;
+        columnsObj[`${prefix}_${generateId()}`] = {
+          title: columnTitle,
+          cards: {}
+        };
+      });
+
+      // Only allow a safe subset of settings to be overridden on creation
+      const allowedOverrideKeys = ['votingEnabled', 'downvotingEnabled', 'multipleVotesAllowed', 'votesPerUser', 'retrospectiveMode', 'sortByVotes'];
+      const sanitizedOverrides = {};
+      if (settingsOverride && typeof settingsOverride === 'object') {
+        allowedOverrideKeys.forEach(k => {
+          if (settingsOverride[k] !== undefined) {
+            sanitizedOverrides[k] = settingsOverride[k];
+          }
+        });
+      }
+
+      const initialData = {
+        title: newBoardTitle,
+        created: Date.now(),
+        owner: user.uid,
+        columns: columnsObj,
+        settings: {
+          votingEnabled: true, // Default to enabled for new boards
+          downvotingEnabled: true, // Default to enabled for new boards
+          multipleVotesAllowed: false, // Default to not allowing multiple votes
+          sortByVotes: false, // Default to chronological
+          retrospectiveMode: false, // Default to disabled (cards are visible)
+          workflowPhase: WORKFLOW_PHASES.CREATION, // Default to creation phase
+          resultsViewIndex: 0, // Default to first result
+          // Apply any overrides parsed from URL (validated/whitelisted)
+          ...sanitizedOverrides
+        }
+      };
+
+      set(newBoardRef, initialData)
         .then(() => {
-          setDarkMode(enabled);
+          setBoardId(newBoardId);
+          setBoardTitle(DEFAULT_BOARD_TITLE);
         })
         .catch(error => {
-          console.error('Error updating dark mode preference:', error);
+          console.error('Error creating board:', error);
         });
-    } else {
-      // If we're not connected to a user yet, just update the local state
-      setDarkMode(enabled);
-    }
-  };
 
-  // Context value
-  const value = {
-    user,
-    boardId,
-    setBoardId,
-    boardTitle,
-    setBoardTitle,
-    columns,
-    updateBoardTitle,
-    sortByVotes,
-    setSortByVotes,
-    votingEnabled,
-    setVotingEnabled,
-    updateVotingEnabled,
-    downvotingEnabled,
-    setDownvotingEnabled,
-    updateDownvotingEnabled,
-    multipleVotesAllowed,
-    setMultipleVotesAllowed,
-    updateMultipleVotesAllowed,
-    votesPerUser,
-    setVotesPerUser,
-    updateVotesPerUser,
-    retrospectiveMode,
-    setRetrospectiveMode,
-    updateRetrospectiveMode,
-    updateBoardSettings,
-    boardRef,
-    createNewBoard,
-    openExistingBoard,
-    moveCard,
-    resetAllVotes,
-    getTotalVotes,
-    getUserVoteCount,
-    getTotalVotesRemaining,
-    darkMode,
-    updateDarkMode,
-    activeUsers,
-    // Workflow phase system
-    workflowPhase,
-    setWorkflowPhase,
-    resultsViewIndex,
-    setResultsViewIndex,
-    startGroupingPhase,
-    startInteractionsPhase,
-    startInteractionRevealPhase,
-    startResultsPhase,
-    startPollPhase,
-    startPollResultsPhase,
-    goToCreationPhase,
-    goToPreviousPhase,
-    navigateResults,
-    getSortedItemsForResults,
-    // Poll system
-    pollVotes,
-    userPollVote,
-    submitPollVote,
-    getPollStats,
-    // Health check system
-    healthCheckVotes,
-    userHealthCheckVotes,
-    submitHealthCheckVote,
-    getHealthCheckStats,
-    startHealthCheckPhase,
-    startHealthCheckResultsPhase,
-    HEALTH_CHECK_QUESTIONS,
-    // Card grouping functions
-    createCardGroup,
-    ungroupCards,
-    removeAllGrouping,
-    updateGroupName,
-    toggleGroupExpanded,
-    upvoteGroup,
-    downvoteGroup,
-    // Card creation activity tracking
-    usersAddingCards,
-    startCardCreation,
-    stopCardCreation,
-    getUsersAddingCardsInColumn,
-    getAllUsersAddingCards,
-    // Timer system
-    timerData,
-    startTimer,
-    pauseTimer,
-    resumeTimer,
-    resetTimer,
-    restartTimer,
-    // Board ownership
-    boardOwner,
-    isOwner: user && boardOwner ? user.uid === boardOwner : false,
-    // Undo/redo system
-    recordAction,
-    undo,
-    redo,
-    canUndo,
-    canRedo,
-    pastCount,
-    futureCount
-  };
+      return newBoardId;
+    };
+
+    // Open an existing board
+    const openExistingBoard = boardIdToOpen => {
+      setBoardId(boardIdToOpen);
+    };
+
+    // Update board title
+    const updateBoardTitle = newTitle => {
+      // Optimistically update the local state first for better UI responsiveness
+      setBoardTitle(newTitle);
+
+      if (boardId && user) {
+        const titleRef = ref(database, `boards/${boardId}/title`);
+        set(titleRef, newTitle)
+          .catch(error => {
+            console.error('Error updating board title:', error);
+          });
+      }
+    };
+
+    // Update dark mode preference
+    const updateDarkMode = enabled => {
+      if (user) {
+        const userPrefsRef = ref(database, `users/${user.uid}/preferences`);
+        set(userPrefsRef, { darkMode: enabled })
+          .then(() => {
+            setDarkMode(enabled);
+          })
+          .catch(error => {
+            console.error('Error updating dark mode preference:', error);
+          });
+      } else {
+        // If we're not connected to a user yet, just update the local state
+        setDarkMode(enabled);
+      }
+    };
+
+    return {
+    user, boardId, setBoardId, boardTitle, setBoardTitle, columns,
+    updateBoardTitle, sortByVotes, setSortByVotes, votingEnabled,
+    setVotingEnabled, updateVotingEnabled, downvotingEnabled,
+    setDownvotingEnabled, updateDownvotingEnabled, multipleVotesAllowed,
+    setMultipleVotesAllowed, updateMultipleVotesAllowed, votesPerUser,
+    setVotesPerUser, updateVotesPerUser, retrospectiveMode,
+    setRetrospectiveMode, updateRetrospectiveMode, updateBoardSettings,
+    boardRef, createNewBoard, openExistingBoard, moveCard, resetAllVotes,
+    getTotalVotes, getUserVoteCount, getTotalVotesRemaining, darkMode,
+      updateDarkMode,
+      activeUsers,
+      // Workflow phase system
+      workflowPhase,
+      setWorkflowPhase,
+    resultsViewIndex, setResultsViewIndex, startGroupingPhase,
+    startInteractionsPhase, startInteractionRevealPhase, startResultsPhase,
+    startPollPhase, startPollResultsPhase, goToCreationPhase,
+    goToPreviousPhase, navigateResults, getSortedItemsForResults,
+      // Poll system
+    pollVotes, userPollVote, submitPollVote, getPollStats,
+      // Health check system
+    healthCheckVotes, userHealthCheckVotes, submitHealthCheckVote,
+    getHealthCheckStats, startHealthCheckPhase, startHealthCheckResultsPhase,
+      HEALTH_CHECK_QUESTIONS,
+      // Card grouping functions
+    createCardGroup, ungroupCards, removeAllGrouping, updateGroupName,
+      toggleGroupExpanded,
+      upvoteGroup,
+      downvoteGroup,
+      // Card creation activity tracking
+      usersAddingCards,
+    startCardCreation, stopCardCreation, getUsersAddingCardsInColumn,
+      getAllUsersAddingCards,
+      // Timer system
+      timerData,
+      startTimer,
+      pauseTimer,
+      resumeTimer,
+      resetTimer,
+      restartTimer,
+      // Board ownership
+      boardOwner,
+      isOwner: user && boardOwner ? user.uid === boardOwner : false,
+      // Undo/redo system
+      recordAction,
+      undo,
+      redo,
+    canUndo, canRedo, pastCount, futureCount
+    };
+  }, [
+    user, boardId, setBoardId, boardTitle, setBoardTitle, columns,
+    sortByVotes, setSortByVotes, votingEnabled,
+    setVotingEnabled, updateVotingEnabled, downvotingEnabled,
+    setDownvotingEnabled, updateDownvotingEnabled, multipleVotesAllowed,
+    setMultipleVotesAllowed, updateMultipleVotesAllowed, votesPerUser,
+    setVotesPerUser, updateVotesPerUser, retrospectiveMode,
+    setRetrospectiveMode, updateRetrospectiveMode, updateBoardSettings,
+    boardRef, moveCard, resetAllVotes,
+    getTotalVotes, getUserVoteCount, getTotalVotesRemaining, darkMode,
+    activeUsers, workflowPhase, setWorkflowPhase,
+    resultsViewIndex, setResultsViewIndex, startGroupingPhase,
+    startInteractionsPhase, startInteractionRevealPhase, startResultsPhase,
+    startPollPhase, startPollResultsPhase, goToCreationPhase,
+    goToPreviousPhase, navigateResults, getSortedItemsForResults,
+    pollVotes, userPollVote, submitPollVote, getPollStats,
+    healthCheckVotes, userHealthCheckVotes, submitHealthCheckVote,
+    getHealthCheckStats, startHealthCheckPhase, startHealthCheckResultsPhase,
+    createCardGroup, ungroupCards, removeAllGrouping, updateGroupName,
+    toggleGroupExpanded, upvoteGroup, downvoteGroup, usersAddingCards,
+    startCardCreation, stopCardCreation, getUsersAddingCardsInColumn,
+    getAllUsersAddingCards, timerData, startTimer, pauseTimer, resumeTimer,
+    resetTimer, restartTimer, boardOwner, recordAction, undo, redo,
+    canUndo, canRedo, pastCount, futureCount
+  ]);
   return <BoardContext.Provider value={value}>{children}</BoardContext.Provider>;
 };
 

--- a/src/hooks/useFocusTrap.js
+++ b/src/hooks/useFocusTrap.js
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+/**
+ * Hook that traps focus within a container element when active.
+ * When activated, focuses the first focusable element inside the container.
+ * Tab/Shift+Tab cycle within the container. Escape closes via onClose callback.
+ * When deactivated, returns focus to the element that was focused before activation.
+ *
+ * @param {React.RefObject} containerRef - Ref to the modal/dialog container element
+ * @param {boolean} isOpen - Whether the trap is active
+ * @param {Object} [options] - Optional configuration
+ * @param {Function} [options.onClose] - Called when Escape is pressed
+ */
+export function useFocusTrap(containerRef, isOpen, options = {}) {
+  const { onClose } = options;
+  const previouslyFocusedRef = useRef(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    // Save the currently focused element so we can restore it later
+    previouslyFocusedRef.current = document.activeElement;
+
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    // Focus the first focusable element after a microtask to let the DOM settle
+    const focusTimer = setTimeout(() => {
+      const focusableElements = container.querySelectorAll(FOCUSABLE_SELECTOR);
+      if (focusableElements.length > 0) {
+        focusableElements[0].focus();
+      }
+    }, 0);
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape' && onClose) {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (e.key !== 'Tab') {
+        return;
+      }
+
+      const focusableElements = container.querySelectorAll(FOCUSABLE_SELECTOR);
+      if (focusableElements.length === 0) {
+        e.preventDefault();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (e.shiftKey) {
+        // Shift+Tab: if on first element, wrap to last
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement.focus();
+        }
+      } else {
+        // Tab: if on last element, wrap to first
+        if (document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      clearTimeout(focusTimer);
+      document.removeEventListener('keydown', handleKeyDown);
+
+      // Restore focus to the previously focused element
+      if (previouslyFocusedRef.current && typeof previouslyFocusedRef.current.focus === 'function') {
+        previouslyFocusedRef.current.focus();
+      }
+    };
+  }, [isOpen, containerRef, onClose]);
+}

--- a/src/hooks/useFocusTrap.test.js
+++ b/src/hooks/useFocusTrap.test.js
@@ -1,0 +1,248 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useFocusTrap } from './useFocusTrap';
+
+describe('useFocusTrap', () => {
+  let container;
+  let button1;
+  let button2;
+  let button3;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    button1 = document.createElement('button');
+    button1.textContent = 'First';
+    button2 = document.createElement('button');
+    button2.textContent = 'Second';
+    button3 = document.createElement('button');
+    button3.textContent = 'Third';
+    container.appendChild(button1);
+    container.appendChild(button2);
+    container.appendChild(button3);
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('focuses the first focusable element when opened', async () => {
+    const ref = { current: container };
+    renderHook(() => useFocusTrap(ref, true));
+
+    // setTimeout(0) in the hook — flush it
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    expect(document.activeElement).toBe(button1);
+  });
+
+  it('does not focus anything when not open', async () => {
+    const outsideButton = document.createElement('button');
+    document.body.appendChild(outsideButton);
+    outsideButton.focus();
+
+    const ref = { current: container };
+    renderHook(() => useFocusTrap(ref, false));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    expect(document.activeElement).toBe(outsideButton);
+    document.body.removeChild(outsideButton);
+  });
+
+  it('wraps focus from last to first on Tab', async () => {
+    const ref = { current: container };
+    renderHook(() => useFocusTrap(ref, true));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // Focus the last button
+    button3.focus();
+    expect(document.activeElement).toBe(button3);
+
+    // Press Tab on the last element
+    const tabEvent = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      bubbles: true,
+      cancelable: true
+    });
+    act(() => {
+      document.dispatchEvent(tabEvent);
+    });
+
+    expect(document.activeElement).toBe(button1);
+  });
+
+  it('wraps focus from first to last on Shift+Tab', async () => {
+    const ref = { current: container };
+    renderHook(() => useFocusTrap(ref, true));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // Focus should be on first button
+    expect(document.activeElement).toBe(button1);
+
+    // Press Shift+Tab on the first element
+    const shiftTabEvent = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    });
+    act(() => {
+      document.dispatchEvent(shiftTabEvent);
+    });
+
+    expect(document.activeElement).toBe(button3);
+  });
+
+  it('calls onClose when Escape is pressed', async () => {
+    const onClose = vi.fn();
+    const ref = { current: container };
+    renderHook(() => useFocusTrap(ref, true, { onClose }));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    const escapeEvent = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true
+    });
+    act(() => {
+      document.dispatchEvent(escapeEvent);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClose on Escape when onClose is not provided', async () => {
+    const ref = { current: container };
+
+    // Should not throw
+    renderHook(() => useFocusTrap(ref, true));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    const escapeEvent = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true
+    });
+
+    expect(() => {
+      act(() => {
+        document.dispatchEvent(escapeEvent);
+      });
+    }).not.toThrow();
+  });
+
+  it('restores focus to previously focused element on close', async () => {
+    const outsideButton = document.createElement('button');
+    outsideButton.textContent = 'Outside';
+    document.body.appendChild(outsideButton);
+    outsideButton.focus();
+    expect(document.activeElement).toBe(outsideButton);
+
+    const ref = { current: container };
+    const { rerender } = renderHook(
+      ({ isOpen }) => useFocusTrap(ref, isOpen),
+      { initialProps: { isOpen: true } }
+    );
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // Focus should have moved into the trap
+    expect(document.activeElement).toBe(button1);
+
+    // Close the trap
+    rerender({ isOpen: false });
+
+    // Focus should be restored to the outside button
+    expect(document.activeElement).toBe(outsideButton);
+
+    document.body.removeChild(outsideButton);
+  });
+
+  it('removes keydown listener on unmount', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const ref = { current: container };
+    const { unmount } = renderHook(() => useFocusTrap(ref, true));
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+    removeSpy.mockRestore();
+  });
+
+  it('handles container with no focusable elements', async () => {
+    const emptyContainer = document.createElement('div');
+    emptyContainer.textContent = 'No buttons here';
+    document.body.appendChild(emptyContainer);
+
+    const ref = { current: emptyContainer };
+
+    // Should not throw
+    renderHook(() => useFocusTrap(ref, true));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // Tab should be prevented (no elements to cycle through)
+    const tabEvent = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      bubbles: true,
+      cancelable: true
+    });
+
+    expect(() => {
+      act(() => {
+        document.dispatchEvent(tabEvent);
+      });
+    }).not.toThrow();
+
+    document.body.removeChild(emptyContainer);
+  });
+
+  it('handles null container ref gracefully', async () => {
+    const ref = { current: null };
+
+    // Should not throw
+    renderHook(() => useFocusTrap(ref, true));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+  });
+
+  it('skips disabled buttons when trapping focus', async () => {
+    const disabledBtn = document.createElement('button');
+    disabledBtn.disabled = true;
+    disabledBtn.textContent = 'Disabled';
+    container.insertBefore(disabledBtn, button1);
+
+    const ref = { current: container };
+    renderHook(() => useFocusTrap(ref, true));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // First focusable should be button1 (not the disabled one)
+    expect(document.activeElement).toBe(button1);
+  });
+});

--- a/src/styles/components/base.css
+++ b/src/styles/components/base.css
@@ -41,3 +41,26 @@ a:hover {
 input, textarea, select, button {
     font-family: inherit;
 }
+
+/* Skip-to-content link: visually hidden until focused */
+.skip-to-content {
+    position: absolute;
+    top: -100%;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10000;
+    padding: 0.75rem 1.5rem;
+    background: var(--accent);
+    color: #fff;
+    border-radius: var(--radius-sm, 4px);
+    font-weight: 600;
+    font-size: 0.875rem;
+    text-decoration: none;
+    transition: top 0.15s ease;
+}
+
+.skip-to-content:focus {
+    top: 0.75rem;
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}

--- a/src/utils/firebase.js
+++ b/src/utils/firebase.js
@@ -3,17 +3,14 @@ import { initializeApp } from 'firebase/app';
 import { getAuth, signInAnonymously } from 'firebase/auth';
 import { getDatabase, get, ref } from 'firebase/database';
 
-// Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
-  // Using the same Firebase configuration from the original app
-  apiKey: 'AIzaSyBIAM_tIBqFUYQl5r-f7e78lNPzc0fIDcM',
-  authDomain: 'big-orca.firebaseapp.com',
-  projectId: 'big-orca',
-  storageBucket: 'big-orca.firebasestorage.app',
-  messagingSenderId: '338206440353',
-  appId: '1:338206440353:web:a6af4374836968379d29e0',
-  databaseURL: 'https://big-orca-default-rtdb.firebaseio.com' // Added databaseURL based on project
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY || 'AIzaSyBIAM_tIBqFUYQl5r-f7e78lNPzc0fIDcM',
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || 'big-orca.firebaseapp.com',
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || 'big-orca',
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || 'big-orca.firebasestorage.app',
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '338206440353',
+  appId: import.meta.env.VITE_FIREBASE_APP_ID || '1:338206440353:web:a6af4374836968379d29e0',
+  databaseURL: import.meta.env.VITE_FIREBASE_DATABASE_URL || 'https://big-orca-default-rtdb.firebaseio.com'
 };
 
 // Initialize Firebase


### PR DESCRIPTION
## Summary

Addresses issues #62, #64, #66, and #68 in a single PR.

### Issue #62 — Remove duplicate revealModeUtils.js
- Already resolved — the duplicate file no longer exists in the codebase. No changes needed.

### Issue #64 — Move Firebase config to environment variables
- `src/utils/firebase.js` now reads from `import.meta.env.VITE_FIREBASE_*` with hardcoded fallbacks for backward compatibility
- Added `.env.example` with all required variable placeholders
- Added `.env` to `.gitignore`

### Issue #66 — Accessibility improvements
- Added skip-to-content link (visible on focus) targeting `#board-content`
- Added `useFocusTrap` hook with focus cycling, Escape-to-close, and focus restoration
- Integrated focus trapping in all modals: ExportBoardModal, NewBoardTemplateModal, VoteLimitModal, and Column group modal
- Added `role="status" aria-live="polite"` to notification element
- Added Space key activation for dashboard board cards (alongside Enter)
- 11 comprehensive tests for the focus trap hook

### Issue #68 — Performance: memoize context values
- Wrapped `BoardContext` value object in `useMemo` with full dependency array
- Wrapped `Card`, `Column`, and `CardGroup` components in `React.memo`
- Updated CardGroup test for memo compatibility (new object reference on rerender)

## Testing
- All 988 tests pass across 63 test suites
- ESLint clean (zero errors/warnings)
- Production build succeeds

Closes #62, closes #64, closes #66, closes #68