### PR TITLE
Replace Yes/No buttons with toggle switches in settings modal

### DIFF
--- a/src/components/Board.test.jsx
+++ b/src/components/Board.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -287,16 +287,9 @@ describe('Board Component', () => {
     const settingsButton = screen.getByTitle('Board settings and preferences');
     fireEvent.click(settingsButton);
 
-    // Find the "Allow Voting?" section and click the "No" option
-    const allowVotingSection = screen.getByText('Allow voting?');
-    expect(allowVotingSection).toBeInTheDocument();
-
-    // Find the closest parent section element containing the setting
-    const votingSection = allowVotingSection.closest('.settings-section');
-
-    // Within that section, find the No option and click it
-    const noOption = within(votingSection).getByText('No');
-    fireEvent.click(noOption);
+    // Find the toggle switch for "Allow voting" and click it
+    const votingToggle = screen.getByRole('switch', { name: 'Allow voting' });
+    fireEvent.click(votingToggle);
 
     // Check that updateVotingEnabled was called with the opposite of its current value
     expect(mockContextValue.updateVotingEnabled).toHaveBeenCalledWith(!mockContextValue.votingEnabled);
@@ -319,18 +312,11 @@ describe('Board Component', () => {
     const settingsButton = screen.getByTitle('Board settings and preferences');
     fireEvent.click(settingsButton);
 
-    // Find the "Allow users to vote multiple times on the same card?" section and click the "Yes" option
-    const allowMultipleVotesSection = screen.getByText('Allow users to vote multiple times on the same card?');
-    expect(allowMultipleVotesSection).toBeInTheDocument();
+    // Find the toggle switch for "Allow multiple votes" and click it
+    const multiVoteToggle = screen.getByRole('switch', { name: /vote multiple times/ });
+    fireEvent.click(multiVoteToggle);
 
-    // Find the closest parent section element containing the setting
-    const multipleVotesSection = allowMultipleVotesSection.closest('.settings-section');
-
-    // Within that section, find the Yes option and click it
-    const yesOption = within(multipleVotesSection).getByText('Yes');
-    fireEvent.click(yesOption);
-
-    // Check that updateMultipleVotesAllowed was called with true
+    // Check that updateMultipleVotesAllowed was called with true (toggling from false)
     expect(mockContextValue.updateMultipleVotesAllowed).toHaveBeenCalledWith(true);
   });
 
@@ -360,11 +346,9 @@ describe('Board Component', () => {
     const settingsButton = screen.getByTitle('Board settings and preferences');
     fireEvent.click(settingsButton);
 
-    // Change the multiple votes setting
-    const allowMultipleVotesSection = screen.getByText('Allow users to vote multiple times on the same card?');
-    const multipleVotesSection = allowMultipleVotesSection.closest('.settings-section');
-    const yesOption = within(multipleVotesSection).getByText('Yes');
-    fireEvent.click(yesOption);
+    // Click the toggle switch for multiple votes
+    const multiVoteToggle = screen.getByRole('switch', { name: /vote multiple times/ });
+    fireEvent.click(multiVoteToggle);
 
     // Verify that only updateMultipleVotesAllowed was called, not updateRetrospectiveMode
     expect(contextWithRetrospectiveMode.updateMultipleVotesAllowed).toHaveBeenCalledWith(true);
@@ -441,18 +425,11 @@ describe('Board Component', () => {
     const settingsButton = screen.getByTitle('Board settings and preferences');
     fireEvent.click(settingsButton);
 
-    // Find the "Allow downvoting?" section and click the "No" option
-    const allowDownvotingSection = screen.getByText('Allow downvoting?');
-    expect(allowDownvotingSection).toBeInTheDocument();
+    // Find the toggle switch for "Allow downvoting" and click it
+    const downvotingToggle = screen.getByRole('switch', { name: 'Allow downvoting' });
+    fireEvent.click(downvotingToggle);
 
-    // Find the closest parent section element containing the setting
-    const downvotingSection = allowDownvotingSection.closest('.settings-section');
-
-    // Within that section, find the No option and click it
-    const noOption = within(downvotingSection).getByText('No');
-    fireEvent.click(noOption);
-
-    // Check that updateDownvotingEnabled was called with false
+    // Check that updateDownvotingEnabled was called with false (toggling from true)
     expect(mockContextValue.updateDownvotingEnabled).toHaveBeenCalledWith(false);
   });
 

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -176,19 +176,16 @@ const SettingsPanel = ({
 
               {/* Voting Settings */}
               <div className="settings-section">
-                <h4 className="settings-section-title">Allow voting?</h4>
-                <div className="settings-boolean-option">
+                <div className="settings-toggle-row">
+                  <span className="settings-toggle-label">Allow voting?</span>
                   <button
-                    className={`boolean-option ${votingEnabled ? 'selected' : ''}`}
-                    onClick={() => updateVotingEnabled(true)}
+                    className="settings-toggle-switch"
+                    role="switch"
+                    aria-checked={votingEnabled}
+                    onClick={() => updateVotingEnabled(!votingEnabled)}
+                    aria-label="Allow voting"
                   >
-                    Yes
-                  </button>
-                  <button
-                    className={`boolean-option ${!votingEnabled ? 'selected' : ''}`}
-                    onClick={() => updateVotingEnabled(false)}
-                  >
-                    No
+                    <span className="settings-toggle-knob"></span>
                   </button>
                 </div>
               </div>
@@ -196,37 +193,31 @@ const SettingsPanel = ({
               {votingEnabled && (
                 <>
                   <div className="settings-section">
-                    <h4 className="settings-section-title">Allow downvoting?</h4>
-                    <div className="settings-boolean-option">
+                    <div className="settings-toggle-row">
+                      <span className="settings-toggle-label">Allow downvoting?</span>
                       <button
-                        className={`boolean-option ${downvotingEnabled ? 'selected' : ''}`}
-                        onClick={() => updateDownvotingEnabled(true)}
+                        className="settings-toggle-switch"
+                        role="switch"
+                        aria-checked={downvotingEnabled}
+                        onClick={() => updateDownvotingEnabled(!downvotingEnabled)}
+                        aria-label="Allow downvoting"
                       >
-                        Yes
-                      </button>
-                      <button
-                        className={`boolean-option ${!downvotingEnabled ? 'selected' : ''}`}
-                        onClick={() => updateDownvotingEnabled(false)}
-                      >
-                        No
+                        <span className="settings-toggle-knob"></span>
                       </button>
                     </div>
                   </div>
 
                   <div className="settings-section">
-                    <h4 className="settings-section-title">Allow users to vote multiple times on the same card?</h4>
-                    <div className="settings-boolean-option">
+                    <div className="settings-toggle-row">
+                      <span className="settings-toggle-label">Allow users to vote multiple times on the same card?</span>
                       <button
-                        className={`boolean-option ${multipleVotesAllowed ? 'selected' : ''}`}
-                        onClick={() => updateMultipleVotesAllowed(true)}
+                        className="settings-toggle-switch"
+                        role="switch"
+                        aria-checked={multipleVotesAllowed}
+                        onClick={() => updateMultipleVotesAllowed(!multipleVotesAllowed)}
+                        aria-label="Allow users to vote multiple times on the same card"
                       >
-                        Yes
-                      </button>
-                      <button
-                        className={`boolean-option ${!multipleVotesAllowed ? 'selected' : ''}`}
-                        onClick={() => updateMultipleVotesAllowed(false)}
-                      >
-                        No
+                        <span className="settings-toggle-knob"></span>
                       </button>
                     </div>
                   </div>
@@ -237,19 +228,16 @@ const SettingsPanel = ({
 
               {/* Retrospective Mode */}
               <div className="settings-section">
-                <h4 className="settings-section-title">Retrospective Mode</h4>
-                <div className="settings-boolean-option">
+                <div className="settings-toggle-row">
+                  <span className="settings-toggle-label">Retrospective Mode</span>
                   <button
-                    className={`boolean-option ${retrospectiveMode ? 'selected' : ''}`}
-                    onClick={() => updateRetrospectiveMode(true)}
+                    className="settings-toggle-switch"
+                    role="switch"
+                    aria-checked={retrospectiveMode}
+                    onClick={() => updateRetrospectiveMode(!retrospectiveMode)}
+                    aria-label="Retrospective Mode"
                   >
-                    On
-                  </button>
-                  <button
-                    className={`boolean-option ${!retrospectiveMode ? 'selected' : ''}`}
-                    onClick={() => updateRetrospectiveMode(false)}
-                  >
-                    Off
+                    <span className="settings-toggle-knob"></span>
                   </button>
                 </div>
                 <p className="settings-hint">

--- a/src/styles/components/header.css
+++ b/src/styles/components/header.css
@@ -327,6 +327,63 @@ h1 {
     border-color: var(--accent);
 }
 
+/* Toggle Switch Styles */
+.settings-toggle-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--space-xs) 0;
+    width: 100%;
+}
+
+.settings-toggle-label {
+    font-size: var(--font-size-sm);
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.settings-toggle-switch {
+    position: relative;
+    width: 40px;
+    height: 22px;
+    border-radius: 11px;
+    background-color: var(--border-color);
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    transition: background-color var(--transition-speed) ease;
+    flex-shrink: 0;
+}
+
+.settings-toggle-switch[aria-checked="true"] {
+    background-color: var(--accent);
+}
+
+.settings-toggle-knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background-color: white;
+    transition: transform var(--transition-speed) ease;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+}
+
+.settings-toggle-switch[aria-checked="true"] .settings-toggle-knob {
+    transform: translateX(18px);
+}
+
+html.light-mode .settings-toggle-switch {
+    background-color: #afb8c1;
+}
+
+html.light-mode .settings-toggle-switch[aria-checked="true"] {
+    background-color: var(--accent);
+}
+
 /* Fallback for browsers that don't support :has() */
 .settings-toggle-btn[aria-expanded="true"] {
     background-color: var(--hover-bg);


### PR DESCRIPTION
## Summary

- Replaces Yes/No and On/Off button pairs with compact toggle switches (`role="switch"` with `aria-checked`) for boolean settings: Allow Voting, Allow Downvoting, Allow Multiple Votes, and Retrospective Mode
- Keeps Appearance (Light/Dark) and Sort Cards (Chronological/By Votes) as button pairs since they represent named choices rather than simple on/off toggles
- Adds toggle switch CSS with proper dark/light mode support, including a contrast fix for the OFF-state track in light mode
- Updates 4 tests in Board.test.jsx to query by `getByRole('switch')` instead of Yes/No text

## Visual

Toggle switches use a pill-shaped track (40×22px) with a sliding knob. ON state uses the accent color; OFF state uses a neutral border color (with light-mode override for contrast).

## Verification

- ✅ Lint: 0 errors, 0 warnings
- ✅ Tests: 982 passed, 0 failures
- ✅ Build: successful
- ✅ Visual: verified in both dark and light modes via browser