### PR TITLE
Add Markdown rendering for cards and comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/user-event": "^13.5.0",
         "firebase": "^11.6.1",
+        "markdown-to-jsx": "^9.7.6",
         "react": "^19.1.0",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
@@ -96,7 +97,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -417,7 +417,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -440,7 +439,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1038,7 +1036,6 @@
       "version": "0.11.5",
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.11.5.tgz",
       "integrity": "sha512-uNp8/Rv12GrrM/dfyqzZCftA2i/5X9axmiEtUDmyQw+0S17EV5s9gudOgdIIGr849LmbAk3At2CBZMqiQJVwNw==",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.13",
         "@firebase/logger": "0.4.4",
@@ -1100,7 +1097,6 @@
       "version": "0.2.54",
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.54.tgz",
       "integrity": "sha512-Vwf29tV/5bHEnp+VPgNWOFMbFG+RSur2ntmzZ19Plp5dJOtoo2nQS817COALLaHlebG/Xf/P5PVHyeQNcSVCqQ==",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.11.5",
         "@firebase/component": "0.6.13",
@@ -1115,8 +1111,7 @@
     "node_modules/@firebase/app-types": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
-      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "peer": true
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw=="
     },
     "node_modules/@firebase/auth": {
       "version": "1.10.1",
@@ -1540,7 +1535,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.11.0.tgz",
       "integrity": "sha512-PzSrhIr++KI6y4P6C/IdgBNMkEx0Ex6554/cYd0Hm+ovyFSJtJXqb/3OSIdnBoa2cpwZT1/GW56EmRc5qEc5fQ==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2093,7 +2087,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2435,7 +2428,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2775,7 +2767,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3443,7 +3434,6 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4778,7 +4768,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -4988,6 +4977,34 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "9.7.6",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-9.7.6.tgz",
+      "integrity": "sha512-oPckbBhWv/d2HmYzSv68g2UBTONmrFYlqUd+juolxTplJImhDEKFgAEcnxSTeZ1HISKzKxm+mVeUYP7OUhglJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "react": ">= 16.0.0",
+        "solid-js": ">=1.0.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/math-intrinsics": {
@@ -5470,7 +5487,6 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5516,7 +5532,6 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6203,7 +6218,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6471,7 +6485,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.3.tgz",
       "integrity": "sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6582,7 +6595,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/user-event": "^13.5.0",
     "firebase": "^11.6.1",
+    "markdown-to-jsx": "^9.7.6",
     "react": "^19.1.0",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",

--- a/src/components/Card.authorship.test.jsx
+++ b/src/components/Card.authorship.test.jsx
@@ -170,7 +170,7 @@ describe('Card Authorship Tests', () => {
     const commentsButton = screen.getByTitle('Toggle comments');
     fireEvent.click(commentsButton);
 
-    const commentContent = screen.getByText('Test comment');
+    const commentContent = screen.getByText('Test comment').closest('.comment-content');
     expect(commentContent).toHaveClass('editable');
     expect(commentContent).toHaveAttribute('title', 'Click to edit');
   });
@@ -192,7 +192,7 @@ describe('Card Authorship Tests', () => {
     const commentsButton = screen.getByTitle('Toggle comments');
     fireEvent.click(commentsButton);
 
-    const commentContent = screen.getByText('Test comment');
+    const commentContent = screen.getByText('Test comment').closest('.comment-content');
     expect(commentContent).not.toHaveClass('editable');
     expect(commentContent).toHaveAttribute('title', 'Only the author can edit this comment');
   });

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -20,6 +20,7 @@ import {
 import CardHoverActions from './CardHoverActions';
 import CardReactions from './CardReactions';
 import Comments from './Comments';
+import MarkdownContent from './MarkdownContent';
 import VotingControls from './VotingControls';
 
 // Card Editor component for editing mode
@@ -50,7 +51,6 @@ const CardEditor = ({
 // Card Content component for display mode
 const CardContent = ({
   cardData,
-  formatContentWithEmojis,
   upvoteCard,
   downvoteCard,
   votingEnabled,
@@ -100,7 +100,7 @@ const CardContent = ({
 
   const displayContent = showObfuscatedText ?
     generateObfuscatedText(cardData.content) :
-    formatContentWithEmojis(cardData.content);
+    cardData.content;
 
   return (
     <div className="card-header">
@@ -115,7 +115,7 @@ const CardContent = ({
         />
       )}
       <div className={`card-content ${!votingEnabled || groupId || !interactionsVisible || (retrospectiveMode && workflowPhase === 'CREATION' && user) ? 'full-width' : ''} ${showObfuscatedText ? 'obfuscated' : ''}`} data-testid="card-content">
-        {displayContent}
+        {showObfuscatedText ? displayContent : <MarkdownContent content={displayContent} />}
       </div>
       {children}
     </div>
@@ -171,9 +171,6 @@ function Card({
     // Voting operations
     upvoteCard,
     downvoteCard,
-
-    // Content formatting
-    formatContentWithEmojis,
 
     // Reaction operations
     hasUserReactedWithEmoji,
@@ -380,7 +377,6 @@ function Card({
         <>
           <CardContent
             cardData={displayCardData}
-            formatContentWithEmojis={formatContentWithEmojis}
             upvoteCard={upvoteCard}
             downvoteCard={downvoteCard}
             votingEnabled={votingEnabled}

--- a/src/components/CardGroup.jsx
+++ b/src/components/CardGroup.jsx
@@ -8,6 +8,7 @@ import { areInteractionsVisible, areOthersInteractionsVisible, areInteractionsAl
 import Card from './Card';
 import Comments from './Comments';
 import EmojiPicker from './EmojiPicker';
+import MarkdownContent from './MarkdownContent';
 import VotingControls from './VotingControls';
 
 /**
@@ -399,7 +400,7 @@ function CardGroup({
             }}
           >
             <div className="card-preview-content">
-              {sortedCards()[0]?.content}
+              <MarkdownContent content={sortedCards()[0]?.content} />
             </div>
           </div>
         </div>

--- a/src/components/Comments.cursor.test.jsx
+++ b/src/components/Comments.cursor.test.jsx
@@ -38,7 +38,7 @@ describe('Comments Cursor Behavior', () => {
       />
     );
 
-    const commentContent = screen.getByText('Test comment');
+    const commentContent = screen.getByText('Test comment').closest('.comment-content');
     expect(commentContent).toHaveClass('editable');
     expect(commentContent).toHaveAttribute('title', 'Click to edit');
   });
@@ -62,7 +62,7 @@ describe('Comments Cursor Behavior', () => {
       />
     );
 
-    const commentContent = screen.getByText('Test comment');
+    const commentContent = screen.getByText('Test comment').closest('.comment-content');
     expect(commentContent).not.toHaveClass('editable');
     expect(commentContent).toHaveAttribute('title', 'Only the author can edit this comment');
   });

--- a/src/components/Comments.jsx
+++ b/src/components/Comments.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { linkifyText } from '../utils/linkify';
 import { shouldHideFeature, getCommentDisabledMessage } from '../utils/retrospectiveModeUtils';
+import MarkdownContent from './MarkdownContent';
 
 const CommentEditor = ({
   editedComment,
@@ -138,7 +138,7 @@ const Comments = React.memo(({
                     : (isCommentAuthor(comment) ? 'Click to edit' : 'Only the author can edit this comment')
                 }
               >
-                {linkifyText(comment.content)}
+                <MarkdownContent content={comment.content} />
               </div>
             )}
           </div>

--- a/src/components/MarkdownContent.jsx
+++ b/src/components/MarkdownContent.jsx
@@ -1,0 +1,75 @@
+import Markdown from 'markdown-to-jsx';
+import { memo, useMemo } from 'react';
+
+/**
+ * Custom link component that opens in new tab with security attrs.
+ * Preserves the `auto-link` class for styling consistency.
+ */
+const MarkdownLink = ({ children, ...props }) => (
+  <a
+    {...props}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="auto-link"
+  >
+    {children}
+  </a>
+);
+
+/**
+ * Markdown rendering options for card/comment content.
+ * - Links open in new tab with noopener/noreferrer
+ * - Images are disabled (security + card compactness)
+ * - iframes/scripts/etc. are voided
+ * - Wrapper is a fragment to avoid extra DOM nesting
+ */
+const markdownOptions = {
+  wrapper: 'span',
+  forceWrapper: true,
+  overrides: {
+    a: { component: MarkdownLink },
+    // Void potentially dangerous elements
+    img: () => null,
+    iframe: () => null,
+    script: () => null,
+    style: () => null,
+    // Keep headings but downsize them for card context
+    h1: { props: { className: 'md-heading' } },
+    h2: { props: { className: 'md-heading' } },
+    h3: { props: { className: 'md-heading' } },
+    h4: { props: { className: 'md-heading' } },
+    h5: { props: { className: 'md-heading' } },
+    h6: { props: { className: 'md-heading' } },
+  },
+};
+
+/**
+ * Renders Markdown content as React components.
+ * Supports: **bold**, *italic*, `code`, ```code blocks```, [links], - lists,
+ * > blockquotes, ~~strikethrough~~
+ *
+ * Uses markdown-to-jsx for component-based rendering (no dangerouslySetInnerHTML).
+ */
+const MarkdownContent = ({ content, className = '' }) => {
+  // Memoize the content to avoid re-parsing on every render
+  const normalizedContent = useMemo(() => {
+    if (!content || typeof content !== 'string') {
+      return '';
+    }
+    return content;
+  }, [content]);
+
+  if (!normalizedContent) {
+    return null;
+  }
+
+  return (
+    <div className={`markdown-content ${className}`.trim()}>
+      <Markdown options={markdownOptions}>
+        {normalizedContent}
+      </Markdown>
+    </div>
+  );
+};
+
+export default memo(MarkdownContent);

--- a/src/components/MarkdownContent.test.jsx
+++ b/src/components/MarkdownContent.test.jsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import { describe, test, expect } from 'vitest';
+import MarkdownContent from './MarkdownContent';
+
+describe('MarkdownContent', () => {
+  test('renders plain text', () => {
+    render(<MarkdownContent content="Hello world" />);
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  test('renders bold text', () => {
+    render(<MarkdownContent content="This is **bold** text" />);
+    const bold = screen.getByText('bold');
+    expect(bold.tagName).toBe('STRONG');
+  });
+
+  test('renders italic text', () => {
+    render(<MarkdownContent content="This is *italic* text" />);
+    const italic = screen.getByText('italic');
+    expect(italic.tagName).toBe('EM');
+  });
+
+  test('renders inline code', () => {
+    render(<MarkdownContent content="Use `console.log()` for debugging" />);
+    const code = screen.getByText('console.log()');
+    expect(code.tagName).toBe('CODE');
+  });
+
+  test('renders code blocks', () => {
+    render(<MarkdownContent content={'```\nconst x = 1;\n```'} />);
+    const codeBlock = screen.getByText('const x = 1;');
+    expect(codeBlock.tagName).toBe('CODE');
+    expect(codeBlock.closest('pre')).toBeInTheDocument();
+  });
+
+  test('renders links with correct attributes', () => {
+    render(<MarkdownContent content="Visit [Example](https://example.com)" />);
+    const link = screen.getByRole('link', { name: 'Example' });
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).toHaveClass('auto-link');
+  });
+
+  test('renders bare URLs as links', () => {
+    render(<MarkdownContent content="Check https://example.com for info" />);
+    const link = screen.getByRole('link', { name: 'https://example.com' });
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveClass('auto-link');
+  });
+
+  test('renders unordered lists', () => {
+    render(<MarkdownContent content={'- Item 1\n- Item 2\n- Item 3'} />);
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+    expect(screen.getByText('Item 3')).toBeInTheDocument();
+  });
+
+  test('renders ordered lists', () => {
+    render(<MarkdownContent content={'1. First\n2. Second\n3. Third'} />);
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+  });
+
+  test('renders blockquotes', () => {
+    render(<MarkdownContent content="> This is a quote" />);
+    const blockquote = screen.getByText('This is a quote').closest('blockquote');
+    expect(blockquote).toBeInTheDocument();
+  });
+
+  test('renders strikethrough', () => {
+    render(<MarkdownContent content="This is ~~deleted~~ text" />);
+    const del = screen.getByText('deleted');
+    expect(del.tagName).toBe('DEL');
+  });
+
+  test('renders headings', () => {
+    render(<MarkdownContent content="# Heading 1" />);
+    const heading = screen.getByText('Heading 1');
+    expect(heading.tagName).toBe('H1');
+  });
+
+  test('voids img tags for security', () => {
+    const { container } = render(<MarkdownContent content="![alt](https://evil.com/xss.png)" />);
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+  });
+
+  test('returns null for empty content', () => {
+    const { container } = render(<MarkdownContent content="" />);
+    expect(container.querySelector('.markdown-content')).not.toBeInTheDocument();
+  });
+
+  test('returns null for null content', () => {
+    const { container } = render(<MarkdownContent content={null} />);
+    expect(container.querySelector('.markdown-content')).not.toBeInTheDocument();
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<MarkdownContent content="Test" className="custom-class" />);
+    expect(container.querySelector('.markdown-content.custom-class')).toBeInTheDocument();
+  });
+
+  test('renders markdown-content wrapper class', () => {
+    const { container } = render(<MarkdownContent content="Test" />);
+    expect(container.querySelector('.markdown-content')).toBeInTheDocument();
+  });
+
+  test('renders mixed markdown content', () => {
+    const content = '**Bold** and *italic* with `code` and a [link](https://example.com)';
+    render(<MarkdownContent content={content} />);
+
+    expect(screen.getByText('Bold').tagName).toBe('STRONG');
+    expect(screen.getByText('italic').tagName).toBe('EM');
+    expect(screen.getByText('code').tagName).toBe('CODE');
+    expect(screen.getByRole('link', { name: 'link' })).toHaveAttribute('href', 'https://example.com');
+  });
+});

--- a/src/hooks/useCardOperations.jsx
+++ b/src/hooks/useCardOperations.jsx
@@ -1,8 +1,7 @@
 import { ref, set, remove } from 'firebase/database';
-import { useState, useCallback, useMemo, useEffect, Fragment } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { useNotification } from '../context/NotificationContext';
 import { database } from '../utils/firebase';
-import { linkifyText } from '../utils/linkify';
 import { areInteractionsDisabled } from '../utils/retrospectiveModeUtils';
 import { areInteractionsRevealed, isCardEditingAllowed } from '../utils/workflowUtils';
 
@@ -285,19 +284,6 @@ export function useCardOperations({
     updateVotes(-1, e, 'Downvoted card');
   }, [updateVotes]);
 
-  // Format content
-  const formatContentWithEmojis = useCallback(content => {
-    if (!content) {
-      return '';
-    }
-
-    return content.split('\n').map((line, i) => (
-      <Fragment key={i}>
-        {linkifyText(line)}
-        {i < content.split('\n').length - 1 && <br />}
-      </Fragment>
-    ));
-  }, []);
 
   // Reaction operations
   const hasUserReactedWithEmoji = useCallback(emoji => {
@@ -541,8 +527,6 @@ export function useCardOperations({
     upvoteCard,
     downvoteCard,
 
-    // Content formatting
-    formatContentWithEmojis,
 
     // Reaction operations
     hasUserReactedWithEmoji,

--- a/src/styles/components/markdown.css
+++ b/src/styles/components/markdown.css
@@ -1,0 +1,152 @@
+/**
+ * Kanban App - Markdown Content Styles
+ * 
+ * Styles for rendered markdown within cards and comments.
+ * Keeps content compact to prevent cards from expanding excessively.
+ */
+
+/* Markdown wrapper — reset spacing for card context */
+.markdown-content {
+    line-height: 1.4;
+    word-break: break-word;
+}
+
+/* Remove top margin from first child and bottom margin from last */
+.markdown-content > span > :first-child {
+    margin-top: 0;
+}
+
+.markdown-content > span > :last-child {
+    margin-bottom: 0;
+}
+
+/* Paragraphs — compact spacing */
+.markdown-content p {
+    margin: 0.25em 0;
+}
+
+/* Headings — scaled down for card context */
+.markdown-content .md-heading,
+.markdown-content h1,
+.markdown-content h2,
+.markdown-content h3,
+.markdown-content h4,
+.markdown-content h5,
+.markdown-content h6 {
+    font-size: var(--font-size-sm);
+    font-weight: 700;
+    margin: 0.4em 0 0.2em;
+    line-height: 1.3;
+    color: var(--text-color);
+}
+
+/* Inline code */
+.markdown-content code {
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, Consolas, monospace;
+    font-size: 0.85em;
+    background: var(--hover-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    padding: 0.1em 0.35em;
+}
+
+/* Code blocks (pre > code) */
+.markdown-content pre {
+    margin: 0.4em 0;
+    padding: var(--space-xs) var(--space-sm);
+    background: var(--hover-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    overflow-x: auto;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.markdown-content pre code {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 0.85em;
+    line-height: 1.5;
+}
+
+/* Lists — compact */
+.markdown-content ul,
+.markdown-content ol {
+    margin: 0.25em 0;
+    padding-left: 1.5em;
+}
+
+.markdown-content li {
+    margin: 0.1em 0;
+}
+
+/* Nested lists */
+.markdown-content li > ul,
+.markdown-content li > ol {
+    margin: 0;
+}
+
+/* Blockquotes */
+.markdown-content blockquote {
+    margin: 0.4em 0;
+    padding: 0.2em 0.6em;
+    border-left: 3px solid var(--accent);
+    color: var(--text-muted);
+    background: var(--hover-bg);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.markdown-content blockquote p {
+    margin: 0.1em 0;
+}
+
+/* Strikethrough */
+.markdown-content del {
+    color: var(--text-muted);
+}
+
+/* Links — reuse auto-link styles from index.css */
+.markdown-content a.auto-link {
+    color: var(--accent);
+    text-decoration: underline;
+}
+
+.markdown-content a.auto-link:hover {
+    color: var(--accent-hover);
+}
+
+/* Strong/Bold */
+.markdown-content strong {
+    font-weight: 700;
+    color: var(--text-color);
+}
+
+/* Emphasis/Italic */
+.markdown-content em {
+    font-style: italic;
+}
+
+/* Horizontal rules */
+.markdown-content hr {
+    border: none;
+    border-top: 1px solid var(--border-color);
+    margin: 0.5em 0;
+}
+
+/* Card preview content — truncate markdown in collapsed groups */
+.card-preview-content .markdown-content {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+}
+
+/* Comment context — even more compact */
+.comment-content .markdown-content {
+    font-size: var(--font-size-sm);
+}
+
+.comment-content .markdown-content pre {
+    max-height: 120px;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -12,6 +12,7 @@
 @import 'components/buttons.css';
 @import 'components/columns.css'; 
 @import 'components/cards.css';
+@import 'components/markdown.css';
 @import 'components/card-groups.css';
 @import 'components/modals.css';
 @import 'components/emoji-reactions.css';


### PR DESCRIPTION
## Summary

- Replaces `formatContentWithEmojis`/`linkifyText` with [`markdown-to-jsx`](https://github.com/quantizor/markdown-to-jsx) for rich text rendering in cards, card group previews, and comments
- Supports **bold**, *italic*, `inline code`, code blocks, links, lists, headings, and blockquotes — all rendered compactly within cards
- Editing mode still shows raw markdown text; display mode renders it
- XSS-safe via component-based rendering (no `dangerouslySetInnerHTML`) with `img`/`iframe`/`script`/`style` elements voided
- CSS styles for markdown elements respect both dark and light themes
- 18 new tests for the `MarkdownContent` component; all 1000 tests pass

## Changes

- **New**: `src/components/MarkdownContent.jsx` — Memoized component wrapping `markdown-to-jsx` with custom link overrides and security voiding
- **New**: `src/components/MarkdownContent.test.jsx` — 18 tests covering all markdown features, edge cases, and security
- **New**: `src/styles/components/markdown.css` — Compact styles for headings, code blocks, blockquotes, lists, and links
- **Modified**: `Card.jsx` — Uses `<MarkdownContent>` instead of `formatContentWithEmojis`
- **Modified**: `Comments.jsx` — Uses `<MarkdownContent>` instead of `linkifyText`
- **Modified**: `CardGroup.jsx` — Uses `<MarkdownContent>` for collapsed group previews
- **Modified**: `useCardOperations.jsx` — Removed `formatContentWithEmojis` function and related imports
- **Modified**: `package.json` — Added `markdown-to-jsx`; `marked` + `dompurify` were already unused

Closes #78