### PR TITLE
Add Playwright E2E tests for dashboard and board flows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  test:
+  unit-tests:
     runs-on: ubuntu-latest
     
     steps:
@@ -23,7 +23,10 @@ jobs:
     - name: Install dependencies
       run: npm ci
       
-    - name: Run tests
+    - name: Run linter
+      run: npm run lint
+
+    - name: Run unit tests
       run: npm test
       
     - name: Upload test results
@@ -34,4 +37,36 @@ jobs:
         path: |
           vitest.results.json
           ./coverage
+        if-no-files-found: ignore
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+        
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps chromium
+      
+    - name: Run E2E tests
+      run: npm run test:e2e
+      
+    - name: Upload Playwright report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: |
+          test-results/
+          playwright-report/
         if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ vitest.results.json
 
 # screenshots from browser automation
 *.png
+
+# Playwright
+/test-results/
+/playwright-report/

--- a/e2e/board.spec.js
+++ b/e2e/board.spec.js
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Helper: create a board via the template modal UI flow.
+ * Waits for auth, clicks New Board, selects default template, clicks Create Board,
+ * then waits for the board view to appear.
+ */
+async function createBoardViaModal(page) {
+  await page.goto('/');
+
+  // Wait for the dashboard to be fully loaded
+  await expect(page.getByRole('button', { name: /new board/i })).toBeVisible();
+
+  // Wait for Firebase auth — the app needs an authenticated user before board creation works.
+  // We poll by checking if clicking "New Board" and "Create Board" results in navigation.
+  // Strategy: click through the modal flow, and if the board doesn't appear,
+  // the auth wasn't ready. Use a retry loop.
+  let boardLoaded = false;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    // Click "New Board" to open the template modal
+    await page.getByRole('button', { name: /new board/i }).click();
+
+    // Wait for the modal to appear
+    const modalHeading = page.getByRole('heading', { name: /choose a board template/i });
+    await expect(modalHeading).toBeVisible({ timeout: 3000 });
+
+    // The default template should already be selected — click "Create Board"
+    await page.getByRole('button', { name: /create board/i }).click();
+
+    // Wait to see if we navigate to the board view
+    try {
+      await expect(page.getByLabel('Board title')).toBeVisible({ timeout: 8000 });
+      boardLoaded = true;
+      break;
+    } catch {
+      // Auth wasn't ready yet — the modal's handleTemplateSelected silently returned.
+      // Wait a bit for auth to complete and try again.
+      // Close the modal if it's still open
+      const cancelBtn = page.getByRole('button', { name: /cancel/i });
+      if (await cancelBtn.isVisible().catch(() => false)) {
+        await cancelBtn.click();
+      }
+      await page.waitForTimeout(3000);
+    }
+  }
+
+  if (!boardLoaded) {
+    throw new Error('Failed to create board after 5 attempts — Firebase auth may not be working');
+  }
+}
+
+test.describe('Board', () => {
+  test('can create a board via template modal and see columns', async ({ page }) => {
+    await createBoardViaModal(page);
+
+    // URL should now contain ?board= parameter
+    await expect(page).toHaveURL(/[?&]board=/);
+
+    // Default template has 3 columns: To Do, In Progress, Done
+    await expect(page.locator('.column')).toHaveCount(3, { timeout: 10000 });
+  });
+
+  test('can add a card to a column', async ({ page }) => {
+    await createBoardViaModal(page);
+
+    // Click "Add Card" on the first column
+    const firstColumn = page.locator('.column').first();
+    await firstColumn.getByRole('button', { name: /add card/i }).click();
+
+    // Should show the inline card form with a textarea
+    const textarea = firstColumn.locator('textarea');
+    await expect(textarea).toBeVisible();
+
+    // Type card content and submit
+    await textarea.fill('My first test card');
+
+    // Click Add to save
+    await firstColumn.getByRole('button', { name: 'Add' }).click();
+
+    // The card should now appear in the column (target the card element, not the textarea)
+    await expect(firstColumn.locator('.card').getByText('My first test card')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('can open and close board settings', async ({ page }) => {
+    await createBoardViaModal(page);
+
+    // Open settings
+    await page.getByRole('button', { name: /board settings/i }).click();
+
+    // Settings modal should appear
+    await expect(page.getByRole('heading', { name: /board settings/i })).toBeVisible();
+
+    // Should show Appearance section
+    await expect(page.getByText('Appearance')).toBeVisible();
+
+    // Close via the close button
+    await page.getByRole('button', { name: /close/i }).click();
+
+    // Settings should be gone
+    await expect(page.getByRole('heading', { name: /board settings/i })).not.toBeVisible();
+  });
+
+  test('can rename the board title', async ({ page }) => {
+    await createBoardViaModal(page);
+
+    const titleInput = page.getByLabel('Board title');
+    await expect(titleInput).toBeVisible();
+
+    // Wait for any pending Firebase syncs to settle before editing
+    await page.waitForTimeout(2000);
+
+    // Clear and type a new title
+    await titleInput.fill('My Test Board');
+    await titleInput.press('Tab');
+
+    // Wait for the Firebase round-trip (write + listener update)
+    await expect(titleInput).toHaveValue('My Test Board', { timeout: 10000 });
+  });
+});

--- a/e2e/dashboard.spec.js
+++ b/e2e/dashboard.spec.js
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dashboard', () => {
+  test('loads the landing page with key elements', async ({ page }) => {
+    await page.goto('/');
+
+    // Should show the app title
+    await expect(page.getByRole('heading', { name: 'Kanbanish' })).toBeVisible();
+
+    // Should show the tagline
+    await expect(page.getByText('Collaborative boards for teams')).toBeVisible();
+
+    // Should show the "New Board" button
+    await expect(page.getByRole('button', { name: /new board/i })).toBeVisible();
+
+    // Should show the join input
+    await expect(page.getByPlaceholder(/paste a board url or id/i)).toBeVisible();
+
+    // Should show feature highlights
+    await expect(page.getByText('Instant setup')).toBeVisible();
+    await expect(page.getByText('Real-time collaboration')).toBeVisible();
+    await expect(page.getByText('No account needed')).toBeVisible();
+  });
+
+  test('opens template modal when clicking New Board', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: /new board/i }).click();
+
+    // Template modal should appear with the heading
+    await expect(page.getByRole('heading', { name: /choose a board template/i })).toBeVisible();
+
+    // Should have a Create Board button
+    await expect(page.getByRole('button', { name: /create board/i })).toBeVisible();
+
+    // Should have a Cancel button
+    await expect(page.getByRole('button', { name: /cancel/i })).toBeVisible();
+
+    // Should have template search input
+    await expect(page.getByPlaceholder(/search templates/i)).toBeVisible();
+  });
+
+  test('can close template modal with Cancel', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: /new board/i }).click();
+    await expect(page.getByRole('heading', { name: /choose a board template/i })).toBeVisible();
+
+    await page.getByRole('button', { name: /cancel/i }).click();
+
+    // Modal should be gone
+    await expect(page.getByRole('heading', { name: /choose a board template/i })).not.toBeVisible();
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -160,7 +160,8 @@ export default [
       'public/manifest.json',
       'coverage/',
       '.vscode/',
-      '.git/'
+      '.git/',
+      'e2e/'
     ]
   }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@playwright/test": "^1.58.2",
         "@testing-library/react": "^16.3.0",
         "@vitejs/plugin-react": "^4.4.1",
         "eslint": "^9.32.0",
@@ -1745,6 +1746,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -5363,6 +5380,53 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,13 @@
     "test:watch": "vitest",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "lint:check": "eslint . --max-warnings 0"
+    "lint:check": "eslint . --max-warnings 0",
+    "test:e2e": "npx playwright test",
+    "test:e2e:headed": "npx playwright test --headed"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
+    "@playwright/test": "^1.58.2",
     "@testing-library/react": "^16.3.0",
     "@vitejs/plugin-react": "^4.4.1",
     "eslint": "^9.32.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'list',
+  timeout: 60000,
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev -- --port 3000',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.js'],
+    exclude: ['e2e/**', 'node_modules/**'],
     reporters: ['default', 'json'],
     outputFile: 'vitest.results.json',
     coverage: {


### PR DESCRIPTION
## Summary

- Adds Playwright-based E2E tests that run in headless Chromium against the real app with live Firebase
- **Dashboard tests** (3): landing page elements, template modal open/close
- **Board tests** (4): board creation via template modal, adding cards, settings modal, renaming board title
- Adds `e2e-tests` CI job alongside existing `unit-tests` in GitHub Actions
- Board tests use a retry-based approach to handle Firebase anonymous auth timing — retries the "New Board → Create Board" modal flow until auth is ready

### Files changed
- \`e2e/dashboard.spec.js\` — 3 dashboard E2E tests
- \`e2e/board.spec.js\` — 4 board E2E tests with \`createBoardViaModal\` helper
- \`playwright.config.js\` — Playwright config (chromium, dev server on port 3000)
- \`.github/workflows/test.yml\` — Added \`e2e-tests\` job with Playwright browser install
- \`package.json\` — Added \`test:e2e\` and \`test:e2e:headed\` scripts, \`@playwright/test\` devDep
- \`vitest.config.js\` — Excluded \`e2e/\` from Vitest
- \`eslint.config.js\` — Excluded \`e2e/\` from ESLint
- \`.gitignore\` — Added \`test-results/\` and \`playwright-report/\`