### PR TITLE
Add card colors and tags (#76)

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -142,7 +142,8 @@ function Card({
     workflowPhase = 'CREATION',
     hideCardAuthorship,
     recordAction,
-    undo
+    undo,
+    boardTags
   } = useBoardContext();
   const cardElementRef = useRef(null);
 
@@ -168,7 +169,8 @@ function Card({
     saveCardChanges,
     deleteCard,
     handleKeyPress,
-
+    setCardColor,
+    setCardTags,
     // Voting operations
     upvoteCard,
     downvoteCard,
@@ -356,6 +358,7 @@ function Card({
     <div
       ref={combinedRef}
       className={`card ${getDynamicClasses()}${dimmed ? ' card-filtered-out' : ''}`}
+      style={{ borderLeft: displayCardData.color ? `4px solid ${displayCardData.color}` : undefined }}
       onClick={handleCardClick}
       data-card-id={cardId}
     >
@@ -403,10 +406,24 @@ function Card({
                 commentCount={Object.keys(displayCardData.comments || {}).length}
                 disabled={!areInteractionsAllowed(workflowPhase, retrospectiveMode)}
                 disabledReason={disabledReason}
+                onColorSelect={setCardColor}
+                onTagAdd={(tag) => setCardTags([...(displayCardData.tags || []), tag])}
+                onTagRemove={(tag) => setCardTags((displayCardData.tags || []).filter(t => t !== tag))}
+                currentColor={displayCardData.color}
+                currentTags={displayCardData.tags || []}
+                boardTags={boardTags}
               />
             )}
           </CardContent>
-          
+
+          {displayCardData.tags && displayCardData.tags.length > 0 && (
+            <div className="card-tags">
+              {displayCardData.tags.map(tag => (
+                <span key={tag} className="card-tag-chip">{tag}</span>
+              ))}
+            </div>
+          )}
+
           {!(retrospectiveMode && workflowPhase === 'CREATION' && user) && areInteractionsVisible(workflowPhase, retrospectiveMode) && !groupId && (
             <CardReactions
               reactions={displayCardData.reactions}

--- a/src/components/CardColorPicker.jsx
+++ b/src/components/CardColorPicker.jsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+import { X, Check } from 'react-feather';
+
+const CARD_COLORS = [
+  '#f85149', // red
+  '#db6d28', // orange
+  '#d29922', // yellow
+  '#2ea043', // green
+  '#58a6ff', // blue
+  '#8b5cf6', // purple
+  '#f472b6', // pink
+  '#6b7280', // gray
+];
+
+const CardColorPicker = React.memo(({
+  position,
+  onColorSelect,
+  onClose,
+  currentColor
+}) => {
+  const pickerRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      // Check if click is outside picker and not on the color button itself
+      if (pickerRef.current && !pickerRef.current.contains(e.target) && !e.target.closest('.color-action')) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [onClose]);
+
+  return ReactDOM.createPortal(
+    <div
+      className="card-color-picker"
+      ref={pickerRef}
+      style={{
+        top: position.top,
+        left: position.left
+      }}
+      onClick={e => e.stopPropagation()}
+    >
+      <button
+        className={`color-option no-color ${!currentColor ? 'selected' : ''}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onColorSelect(null);
+          onClose();
+        }}
+        title="No color"
+        aria-label="No color"
+      >
+        <X size={14} />
+      </button>
+      {CARD_COLORS.map(color => (
+        <button
+          key={color}
+          className={`color-option ${currentColor === color ? 'selected' : ''}`}
+          style={{ backgroundColor: color }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onColorSelect(color);
+            onClose();
+          }}
+          title={color}
+          aria-label={`Select color ${color}`}
+        >
+          {currentColor === color && <Check size={14} color="#fff" />}
+        </button>
+      ))}
+    </div>,
+    document.body
+  );
+});
+
+export default CardColorPicker;

--- a/src/components/CardHoverActions.jsx
+++ b/src/components/CardHoverActions.jsx
@@ -1,10 +1,12 @@
-import React, { useRef } from 'react';
-import { MessageSquare, Smile } from 'react-feather';
+import React, { useRef, useState } from 'react';
+import { MessageSquare, Smile, Droplet, Tag } from 'react-feather';
 import {
   shouldUseDisabledStyling,
   shouldHideFeature,
   getReactionDisabledMessage
 } from '../utils/retrospectiveModeUtils';
+import CardColorPicker from './CardColorPicker';
+import CardTagPicker from './CardTagPicker';
 import EmojiPicker from './EmojiPicker';
 
 const CardHoverActions = React.memo(({
@@ -18,9 +20,22 @@ const CardHoverActions = React.memo(({
   hasUserReactedWithEmoji,
   commentCount = 0,
   disabled = false,
-  disabledReason = 'cards-not-revealed'
+  disabledReason = 'cards-not-revealed',
+  onColorSelect,
+  onTagAdd,
+  onTagRemove,
+  currentColor,
+  currentTags,
+  boardTags
 }) => {
   const emojiButtonRef = useRef(null);
+  const colorButtonRef = useRef(null);
+  const tagButtonRef = useRef(null);
+
+  const [showColorPicker, setShowColorPicker] = useState(false);
+  const [showTagPicker, setShowTagPicker] = useState(false);
+  const [colorPickerPosition, setColorPickerPosition] = useState({ top: 0, left: 0 });
+  const [tagPickerPosition, setTagPickerPosition] = useState({ top: 0, left: 0 });
 
   // Use utility functions for consistent logic
   const useDisabledStyling = shouldUseDisabledStyling(disabled, disabledReason);
@@ -36,28 +51,96 @@ const CardHoverActions = React.memo(({
           hasUserReactedWithEmoji={hasUserReactedWithEmoji}
         />
       )}
+      {showColorPicker && (
+        <CardColorPicker
+          position={colorPickerPosition}
+          onColorSelect={onColorSelect}
+          onClose={() => setShowColorPicker(false)}
+          currentColor={currentColor}
+        />
+      )}
+      {showTagPicker && (
+        <CardTagPicker
+          position={tagPickerPosition}
+          onTagAdd={onTagAdd}
+          onTagRemove={onTagRemove}
+          currentTags={currentTags}
+          boardTags={boardTags}
+          onClose={() => setShowTagPicker(false)}
+        />
+      )}
       {!hideAddButton && (
-        <button
-          className={`card-hover-action emoji-action ${useDisabledStyling ? 'disabled' : ''}`}
-          onClick={disabled ? undefined : e => {
-            e.stopPropagation();
-            if (emojiButtonRef.current) {
-              const buttonRect = emojiButtonRef.current.getBoundingClientRect();
-              setEmojiPickerPosition({
-                top: buttonRect.bottom + window.scrollY + 5,
-                left: buttonRect.left + window.scrollX
-              });
-            }
-            setShowEmojiPicker(!showEmojiPicker);
-            setShowComments(false);
-          }}
-          title={disabled ? getReactionDisabledMessage(disabledReason) : 'Add reaction'}
-          aria-label="Add reaction"
-          ref={emojiButtonRef}
-          disabled={useDisabledStyling}
-        >
-          <Smile size={16} aria-hidden="true" />
-        </button>
+        <>
+          <button
+            className={`card-hover-action color-action ${useDisabledStyling ? 'disabled' : ''}`}
+            onClick={disabled ? undefined : e => {
+              e.stopPropagation();
+              if (colorButtonRef.current) {
+                const buttonRect = colorButtonRef.current.getBoundingClientRect();
+                setColorPickerPosition({
+                  top: buttonRect.bottom + window.scrollY + 5,
+                  left: buttonRect.left + window.scrollX
+                });
+              }
+              setShowColorPicker(!showColorPicker);
+              setShowEmojiPicker(false);
+              setShowTagPicker(false);
+              setShowComments(false);
+            }}
+            title={disabled ? getReactionDisabledMessage(disabledReason) : 'Set color'}
+            aria-label="Set color"
+            ref={colorButtonRef}
+            disabled={useDisabledStyling}
+          >
+            <Droplet size={16} aria-hidden="true" />
+          </button>
+          <button
+            className={`card-hover-action tag-action ${useDisabledStyling ? 'disabled' : ''}`}
+            onClick={disabled ? undefined : e => {
+              e.stopPropagation();
+              if (tagButtonRef.current) {
+                const buttonRect = tagButtonRef.current.getBoundingClientRect();
+                setTagPickerPosition({
+                  top: buttonRect.bottom + window.scrollY + 5,
+                  left: buttonRect.left + window.scrollX
+                });
+              }
+              setShowTagPicker(!showTagPicker);
+              setShowEmojiPicker(false);
+              setShowColorPicker(false);
+              setShowComments(false);
+            }}
+            title={disabled ? getReactionDisabledMessage(disabledReason) : 'Add tags'}
+            aria-label="Add tags"
+            ref={tagButtonRef}
+            disabled={useDisabledStyling}
+          >
+            <Tag size={16} aria-hidden="true" />
+          </button>
+          <button
+            className={`card-hover-action emoji-action ${useDisabledStyling ? 'disabled' : ''}`}
+            onClick={disabled ? undefined : e => {
+              e.stopPropagation();
+              if (emojiButtonRef.current) {
+                const buttonRect = emojiButtonRef.current.getBoundingClientRect();
+                setEmojiPickerPosition({
+                  top: buttonRect.bottom + window.scrollY + 5,
+                  left: buttonRect.left + window.scrollX
+                });
+              }
+              setShowEmojiPicker(!showEmojiPicker);
+              setShowColorPicker(false);
+              setShowTagPicker(false);
+              setShowComments(false);
+            }}
+            title={disabled ? getReactionDisabledMessage(disabledReason) : 'Add reaction'}
+            aria-label="Add reaction"
+            ref={emojiButtonRef}
+            disabled={useDisabledStyling}
+          >
+            <Smile size={16} aria-hidden="true" />
+          </button>
+        </>
       )}
       {/* Show comment button on hover only */}
       <button

--- a/src/components/CardTagPicker.jsx
+++ b/src/components/CardTagPicker.jsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect, useRef, useMemo } from 'react';
+import ReactDOM from 'react-dom';
+
+const CardTagPicker = React.memo(({
+  position,
+  onTagAdd,
+  onTagRemove,
+  currentTags = [],
+  boardTags = [],
+  onClose
+}) => {
+  const [inputValue, setInputValue] = useState('');
+  const pickerRef = useRef(null);
+  
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (pickerRef.current && !pickerRef.current.contains(e.target) && !e.target.closest('.tag-action')) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [onClose]);
+
+  const handleAddTag = (e) => {
+    e.preventDefault();
+    const newTag = inputValue.trim();
+    if (newTag && newTag.length <= 20 && !currentTags.includes(newTag)) {
+      onTagAdd(newTag);
+      setInputValue('');
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      handleAddTag(e);
+    } else if (e.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  const toggleTag = (tag) => {
+    if (currentTags.includes(tag)) {
+      onTagRemove(tag);
+    } else {
+      onTagAdd(tag);
+    }
+  };
+
+  const filteredBoardTags = useMemo(() => {
+    if (!inputValue.trim()) return boardTags;
+    const lowerInput = inputValue.toLowerCase().trim();
+    return boardTags.filter(tag => tag.toLowerCase().includes(lowerInput));
+  }, [boardTags, inputValue]);
+
+  return ReactDOM.createPortal(
+    <div
+      className="card-tag-picker"
+      ref={pickerRef}
+      style={{
+        top: position.top,
+        left: position.left
+      }}
+      onClick={e => e.stopPropagation()}
+    >
+      <input
+        type="text"
+        className="tag-picker-input"
+        placeholder="Add a tag..."
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value.slice(0, 20))}
+        onKeyDown={handleKeyDown}
+        autoFocus
+        maxLength={20}
+      />
+      <div className="tag-picker-tags">
+        {filteredBoardTags.map(tag => (
+          <button
+            key={tag}
+            className={`tag-picker-tag ${currentTags.includes(tag) ? 'active' : ''}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleTag(tag);
+            }}
+          >
+            {tag}
+          </button>
+        ))}
+        {filteredBoardTags.length === 0 && !inputValue.trim() && (
+          <div className="tag-picker-empty">No existing tags. Type to create one!</div>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+});
+
+export default CardTagPicker;

--- a/src/components/modals/ExportBoardModal.jsx
+++ b/src/components/modals/ExportBoardModal.jsx
@@ -90,6 +90,8 @@ const ExportBoardModal = ({ isOpen, onClose }) => {
               const processedCard = {
                 content: card.content,
                 votes: card.votes || 0,
+                color: card.color || null,
+                tags: card.tags || [],
                 comments: [],
                 reactions: []
               };
@@ -132,6 +134,8 @@ const ExportBoardModal = ({ isOpen, onClose }) => {
             const processedCard = {
               content: card.content,
               votes: card.votes || 0,
+              color: card.color || null,
+              tags: card.tags || [],
               comments: [],
               reactions: []
             };
@@ -212,7 +216,8 @@ const ExportBoardModal = ({ isOpen, onClose }) => {
           // Cards within the group as list items
           group.cards.forEach(card => {
             const voteCount = card.votes;
-            markdown += `- **${card.content}** ${voteCount > 0 ? `(${voteCount} votes)` : ''}\n`;
+            const tagsStr = card.tags && card.tags.length > 0 ? ` [${card.tags.join('] [')}]` : '';
+            markdown += `- **${card.content}** ${voteCount > 0 ? `(${voteCount} votes)` : ''}${tagsStr}\n`;
 
             // Comments - indented under the list item
             if (card.comments.length > 0) {
@@ -242,9 +247,10 @@ const ExportBoardModal = ({ isOpen, onClose }) => {
       column.cards.forEach(card => {
         // Card content as heading with vote count
         const voteCount = card.votes;
+        const tagsStr = card.tags && card.tags.length > 0 ? ` [${card.tags.join('] [')}]` : '';
 
         // Use content as heading/title
-        markdown += `### ${card.content} ${voteCount > 0 ? `(${voteCount} votes)` : ''}\n\n`;
+        markdown += `### ${card.content} ${voteCount > 0 ? `(${voteCount} votes)` : ''}${tagsStr}\n\n`;
 
         // Comments
         if (card.comments.length > 0) {
@@ -312,7 +318,8 @@ const ExportBoardModal = ({ isOpen, onClose }) => {
           // Cards within the group
           group.cards.forEach(card => {
             const voteCount = card.votes;
-            const content = `  • ${card.content} ${voteCount > 0 ? `(${voteCount} votes)` : ''}`;
+            const tagsStr = card.tags && card.tags.length > 0 ? ` (tags: ${card.tags.join(', ')})` : '';
+            const content = `  • ${card.content} ${voteCount > 0 ? `(${voteCount} votes)` : ''}${tagsStr}`;
             text += `${content}\n`;
 
             // Comments
@@ -343,8 +350,9 @@ const ExportBoardModal = ({ isOpen, onClose }) => {
       column.cards.forEach(card => {
         // Card content as heading with vote count
         const voteCount = card.votes;
+        const tagsStr = card.tags && card.tags.length > 0 ? ` (tags: ${card.tags.join(', ')})` : '';
         const content = card.content;
-        text += `${content} ${voteCount > 0 ? `(${voteCount} votes)` : ''}\n${'-'.repeat(content.length)}\n\n`;
+        text += `${content} ${voteCount > 0 ? `(${voteCount} votes)` : ''}${tagsStr}\n${'-'.repeat(content.length)}\n\n`;
 
         // Comments
         if (card.comments.length > 0) {

--- a/src/context/BoardContext.jsx
+++ b/src/context/BoardContext.jsx
@@ -282,6 +282,21 @@ export const BoardProvider = ({ children, initialBoardId = null }) => {
     boardId, user, timerData, setTimerData, workflowPhase
   });
 
+  // Compute board-wide tags
+  const boardTags = useMemo(() => {
+    const tagsSet = new Set();
+    Object.values(columns || {}).forEach(column => {
+      if (column.cards) {
+        Object.values(column.cards).forEach(card => {
+          if (card.tags && Array.isArray(card.tags)) {
+            card.tags.forEach(tag => tagsSet.add(tag));
+          }
+        });
+      }
+    });
+    return Array.from(tagsSet).sort();
+  }, [columns]);
+
   // Context value
   const value = useMemo(() => {
     // Create a new board with specified template columns, title, and optional settings overrides
@@ -424,6 +439,8 @@ export const BoardProvider = ({ children, initialBoardId = null }) => {
     boardRef, createNewBoard, openExistingBoard, moveCard, resetAllVotes,
     getTotalVotes, getUserVoteCount, getTotalVotesRemaining, darkMode,
       updateDarkMode,
+      // Tags
+      boardTags,
       // Screen sharing mode
       hideCardAuthorship,
       updateHideCardAuthorship,
@@ -475,7 +492,7 @@ export const BoardProvider = ({ children, initialBoardId = null }) => {
     setVotesPerUser, updateVotesPerUser, retrospectiveMode,
     setRetrospectiveMode, updateRetrospectiveMode, updateBoardSettings,
     boardRef, moveCard, resetAllVotes,
-    getTotalVotes, getUserVoteCount, getTotalVotesRemaining, darkMode,
+    getTotalVotes, getUserVoteCount, getTotalVotesRemaining, darkMode, boardTags,
     hideCardAuthorship,
     activeUsers, workflowPhase, setWorkflowPhase,
     resultsViewIndex, setResultsViewIndex, startGroupingPhase,

--- a/src/hooks/useCardOperations.jsx
+++ b/src/hooks/useCardOperations.jsx
@@ -500,6 +500,34 @@ export function useCardOperations({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showEmojiPicker]);
 
+  const setCardColor = useCallback(async color => {
+    if (!boardId) return;
+    try {
+      const colorRef = ref(database, `boards/${boardId}/columns/${columnId}/cards/${cardId}/color`);
+      if (color) {
+        await set(colorRef, color);
+      } else {
+        await remove(colorRef);
+      }
+    } catch (error) {
+      console.error('Error setting card color:', error);
+    }
+  }, [boardId, columnId, cardId]);
+
+  const setCardTags = useCallback(async tags => {
+    if (!boardId) return;
+    try {
+      const tagsRef = ref(database, `boards/${boardId}/columns/${columnId}/cards/${cardId}/tags`);
+      if (tags && tags.length > 0) {
+        await set(tagsRef, tags);
+      } else {
+        await remove(tagsRef);
+      }
+    } catch (error) {
+      console.error('Error setting card tags:', error);
+    }
+  }, [boardId, columnId, cardId]);
+
   return {
     // State
     isEditing,
@@ -522,11 +550,12 @@ export function useCardOperations({
     saveCardChanges,
     deleteCard,
     handleKeyPress,
+    setCardColor,
+    setCardTags,
 
     // Voting operations
     upvoteCard,
     downvoteCard,
-
 
     // Reaction operations
     hasUserReactedWithEmoji,

--- a/src/styles/components/cards.css
+++ b/src/styles/components/cards.css
@@ -695,3 +695,149 @@
 .card-highlight {
     animation: card-highlight 2s ease-out forwards;
 }
+
+/* Card color strip */
+.card[style*="border-left"] {
+    padding-left: calc(var(--space-sm) - 2px); /* compensate for thicker border */
+}
+
+/* Card tags */
+.card-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xxs);
+    padding: 0;
+    margin-top: var(--space-xs);
+    margin-bottom: calc(-1 * var(--space-xxs));
+}
+
+.card-tag-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 8px;
+    border-radius: var(--radius-round);
+    background: var(--accent-transparent-light);
+    color: var(--accent);
+    font-size: var(--font-size-xs);
+    font-weight: 500;
+    line-height: 1.6;
+    white-space: nowrap;
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Card color picker */
+.card-color-picker {
+    position: fixed;
+    z-index: 1000;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: var(--space-sm);
+    box-shadow: var(--shadow-lg);
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--space-xs);
+    min-width: 140px;
+}
+
+.color-option {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform var(--transition-speed), border-color var(--transition-speed);
+}
+
+.color-option:hover {
+    transform: scale(1.15);
+    border-color: var(--text-muted);
+}
+
+.color-option.selected {
+    border-color: var(--text-color);
+    box-shadow: 0 0 0 2px var(--card-bg), 0 0 0 4px var(--text-color);
+}
+
+.color-option.no-color {
+    background: var(--hover-bg);
+    border: 2px dashed var(--border-color);
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+/* Card tag picker */
+.card-tag-picker {
+    position: fixed;
+    z-index: 1000;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: var(--space-sm);
+    box-shadow: var(--shadow-lg);
+    min-width: 200px;
+    max-width: 260px;
+}
+
+.tag-picker-input {
+    width: 100%;
+    padding: var(--space-xxs) var(--space-xs);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: var(--input-bg, var(--bg-color));
+    color: var(--text-color);
+    font-size: var(--font-size-sm);
+    font-family: inherit;
+    margin-bottom: var(--space-xs);
+}
+
+.tag-picker-input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent-transparent);
+}
+
+.tag-picker-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xxs);
+    max-height: 120px;
+    overflow-y: auto;
+}
+
+.tag-picker-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 10px;
+    border-radius: var(--radius-round);
+    background: var(--hover-bg);
+    color: var(--text-color);
+    font-size: var(--font-size-xs);
+    cursor: pointer;
+    border: 1px solid var(--border-color);
+    transition: all var(--transition-speed);
+}
+
+.tag-picker-tag:hover {
+    background: var(--accent-transparent-light);
+    border-color: var(--accent);
+}
+
+.tag-picker-tag.active {
+    background: var(--accent-transparent);
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.tag-picker-empty {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-style: italic;
+    padding: var(--space-xs);
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- Adds card color labeling with 8 preset colors via a color picker popover (portal-based, click-outside-to-close)
- Adds card tagging with free-text input and board-wide tag autocomplete — tags display as styled chips below card content
- Color applied as a left border strip on the card for quick visual categorization
- Tags and colors included in board export (markdown and plaintext)

## Changes
- **New**: `CardColorPicker.jsx` — portal-based color picker with 8 presets + no-color option
- **New**: `CardTagPicker.jsx` — portal-based tag picker with autocomplete from board-wide tags
- **Modified**: `useCardOperations.jsx` — added `setCardColor()` and `setCardTags()` Firebase operations
- **Modified**: `BoardContext.jsx` — added `boardTags` useMemo for cross-card tag suggestions
- **Modified**: `Card.jsx` — renders color border strip and tag chips
- **Modified**: `CardHoverActions.jsx` — added Droplet/Tag action buttons with picker state
- **Modified**: `ExportBoardModal.jsx` — includes color/tags in export output
- **Modified**: `cards.css` — styles for color picker, tag picker, and tag chips

Closes #76