### PR TITLE
Export board to Markdown, CSV, and JSON with download support

### DIFF
--- a/src/components/ExportBoardModal.test.jsx
+++ b/src/components/ExportBoardModal.test.jsx
@@ -34,13 +34,24 @@ const mockBoardContext = {
           content: 'Grouped card 2', 
           votes: 1,
           groupId: 'group1'
+        },
+        'card4': {
+          content: 'Tagged card',
+          votes: 0,
+          tags: ['urgent', 'bug']
         }
       },
       groups: {
         'group1': {
           name: 'Test Group',
           votes: 5,
-          cardIds: ['card2', 'card3']
+          cardIds: ['card2', 'card3'],
+          comments: {
+            'gcomment1': { content: 'Group-level comment' }
+          },
+          reactions: {
+            '🔥': { count: 3 }
+          }
         }
       }
     }
@@ -48,7 +59,8 @@ const mockBoardContext = {
 };
 
 vi.mock('../context/BoardContext', () => ({
-  useBoardContext: () => mockBoardContext
+  useBoardContext: () => mockBoardContext,
+  DEFAULT_BOARD_TITLE: 'My Board'
 }));
 // Mock the NotificationContext
 const { mockShowNotification } = vi.hoisted(() => ({
@@ -139,5 +151,280 @@ describe('ExportBoardModal with Card Grouping', () => {
     // Check that ungrouped card comments are not indented  
     expect(content).toContain('Comments:\n- Test comment');
     expect(content).toContain('👍 (1)');
+  });
+});
+
+describe('ExportBoardModal - CSV format', () => {
+  const mockProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('generates CSV with correct headers', () => {
+    render(<ExportBoardModal {...mockProps} />);
+
+    const csvRadio = screen.getByRole('radio', { name: /csv/i });
+    fireEvent.click(csvRadio);
+
+    const exportContent = screen.getByRole('textbox');
+    const content = exportContent.value;
+    const lines = content.split('\n');
+
+    expect(lines[0]).toBe('Column,Group,Card,Votes,Tags,Comments,Reactions');
+  });
+
+  test('includes grouped and ungrouped cards in CSV', () => {
+    render(<ExportBoardModal {...mockProps} />);
+
+    const csvRadio = screen.getByRole('radio', { name: /csv/i });
+    fireEvent.click(csvRadio);
+
+    const exportContent = screen.getByRole('textbox');
+    const content = exportContent.value;
+
+    // Check group row exists with group-level data
+    expect(content).toContain('To Do');
+    expect(content).toContain('Test Group');
+    expect(content).toContain('Grouped card 1');
+    expect(content).toContain('Grouped card 2');
+    expect(content).toContain('Individual card');
+  });
+
+  test('properly escapes CSV fields with commas', () => {
+    render(<ExportBoardModal {...mockProps} />);
+
+    const csvRadio = screen.getByRole('radio', { name: /csv/i });
+    fireEvent.click(csvRadio);
+
+    const exportContent = screen.getByRole('textbox');
+    const content = exportContent.value;
+
+    // Tags should be comma-separated and quoted in CSV
+    expect(content).toContain('"urgent, bug"');
+  });
+
+  test('includes reactions in CSV format', () => {
+    render(<ExportBoardModal {...mockProps} />);
+
+    const csvRadio = screen.getByRole('radio', { name: /csv/i });
+    fireEvent.click(csvRadio);
+
+    const exportContent = screen.getByRole('textbox');
+    const content = exportContent.value;
+
+    // Card reactions
+    expect(content).toContain('🎉 (2)');
+    expect(content).toContain('👍 (1)');
+    // Group reactions
+    expect(content).toContain('🔥 (3)');
+  });
+});
+
+describe('ExportBoardModal - JSON format', () => {
+  const mockProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('generates valid JSON', () => {
+    render(<ExportBoardModal {...mockProps} />);
+
+    const jsonRadio = screen.getByRole('radio', { name: /json/i });
+    fireEvent.click(jsonRadio);
+
+    const exportContent = screen.getByRole('textbox');
+    const content = exportContent.value;
+
+    // Should be valid JSON
+    const parsed = JSON.parse(content);
+    expect(parsed).toBeDefined();
+    expect(parsed.title).toBe('Test Board');
+  });
+
+  test('JSON contains complete board structure', () => {
+    render(<ExportBoardModal {...mockProps} />);
+
+    const jsonRadio = screen.getByRole('radio', { name: /json/i });
+    fireEvent.click(jsonRadio);
+
+    const exportContent = screen.getByRole('textbox');
+    const parsed = JSON.parse(exportContent.value);
+
+    // Check top-level structure
+    expect(parsed.title).toBe('Test Board');
+    expect(parsed.columns).toHaveLength(1);
+    expect(parsed.columns[0].title).toBe('To Do');
+
+    // Check groups
+    expect(parsed.columns[0].groups).toHaveLength(1);
+    expect(parsed.columns[0].groups[0].name).toBe('Test Group');
+    expect(parsed.columns[0].groups[0].votes).toBe(5);
+    expect(parsed.columns[0].groups[0].cards).toHaveLength(2);
+
+    // Check ungrouped cards
+    const ungroupedCards = parsed.columns[0].cards;
+    expect(ungroupedCards.length).toBeGreaterThanOrEqual(1);
+    const individualCard = ungroupedCards.find(c => c.content === 'Individual card');
+    expect(individualCard).toBeDefined();
+    expect(individualCard.votes).toBe(2);
+  });
+
+  test('JSON includes comments and reactions', () => {
+    render(<ExportBoardModal {...mockProps} />);
+
+    const jsonRadio = screen.getByRole('radio', { name: /json/i });
+    fireEvent.click(jsonRadio);
+
+    const exportContent = screen.getByRole('textbox');
+    const parsed = JSON.parse(exportContent.value);
+
+    // Check card comments
+    const individualCard = parsed.columns[0].cards.find(c => c.content === 'Individual card');
+    expect(individualCard.comments).toContain('Test comment');
+    expect(individualCard.reactions).toEqual([{ emoji: '👍', count: 1 }]);
+
+    // Check group-level data
+    const group = parsed.columns[0].groups[0];
+    expect(group.comments).toContain('Group-level comment');
+    expect(group.reactions).toEqual([{ emoji: '🔥', count: 3 }]);
+
+    // Check grouped card comments
+    const groupedCard = group.cards.find(c => c.content === 'Grouped card 1');
+    expect(groupedCard.comments).toContain('Group comment');
+  });
+
+  test('JSON includes tags', () => {
+    render(<ExportBoardModal {...mockProps} />);
+
+    const jsonRadio = screen.getByRole('radio', { name: /json/i });
+    fireEvent.click(jsonRadio);
+
+    const exportContent = screen.getByRole('textbox');
+    const parsed = JSON.parse(exportContent.value);
+
+    const taggedCard = parsed.columns[0].cards.find(c => c.content === 'Tagged card');
+    expect(taggedCard).toBeDefined();
+    expect(taggedCard.tags).toEqual(['urgent', 'bug']);
+  });
+});
+
+describe('ExportBoardModal - format selector UI', () => {
+  const mockProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('renders all four format options', () => {
+    render(<ExportBoardModal {...mockProps} />);
+
+    expect(screen.getByRole('radio', { name: /markdown/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /plain text/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /csv/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /json/i })).toBeInTheDocument();
+  });
+
+  test('defaults to markdown format', () => {
+    render(<ExportBoardModal {...mockProps} />);
+
+    const markdownRadio = screen.getByRole('radio', { name: /markdown/i });
+    expect(markdownRadio).toBeChecked();
+  });
+
+  test('shows copy and download buttons', () => {
+    render(<ExportBoardModal {...mockProps} />);
+
+    expect(screen.getByText('Copy to Clipboard')).toBeInTheDocument();
+    expect(screen.getByText('Download File')).toBeInTheDocument();
+  });
+
+  test('copy to clipboard calls navigator API', async () => {
+    const mockWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText: mockWriteText }
+    });
+
+    render(<ExportBoardModal {...mockProps} />);
+
+    const copyButton = screen.getByText('Copy to Clipboard');
+    fireEvent.click(copyButton);
+
+    expect(mockWriteText).toHaveBeenCalled();
+  });
+});
+
+describe('ExportBoardModal - download', () => {
+  const mockProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('download creates a blob and triggers download', () => {
+    const mockCreateObjectURL = vi.fn().mockReturnValue('blob:test');
+    const mockRevokeObjectURL = vi.fn();
+    global.URL.createObjectURL = mockCreateObjectURL;
+    global.URL.revokeObjectURL = mockRevokeObjectURL;
+
+    render(<ExportBoardModal {...mockProps} />);
+
+    const downloadButton = screen.getByText('Download File');
+    fireEvent.click(downloadButton);
+
+    // Verify Blob was created and URL lifecycle was managed
+    expect(mockCreateObjectURL).toHaveBeenCalled();
+    const blobArg = mockCreateObjectURL.mock.calls[0][0];
+    expect(blobArg).toBeInstanceOf(Blob);
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:test');
+  });
+
+  test('download uses correct file extension for each format', () => {
+    const mockCreateObjectURL = vi.fn().mockReturnValue('blob:test');
+    const mockRevokeObjectURL = vi.fn();
+    global.URL.createObjectURL = mockCreateObjectURL;
+    global.URL.revokeObjectURL = mockRevokeObjectURL;
+
+    // Track created anchor elements
+    const createdLinks = [];
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      const el = originalCreateElement(tag);
+      if (tag === 'a') {
+        createdLinks.push(el);
+      }
+      return el;
+    });
+
+    render(<ExportBoardModal {...mockProps} />);
+
+    // Test markdown (default)
+    fireEvent.click(screen.getByText('Download File'));
+    expect(createdLinks[createdLinks.length - 1].download).toMatch(/\.md$/);
+
+    // Switch to CSV and download
+    fireEvent.click(screen.getByRole('radio', { name: /csv/i }));
+    fireEvent.click(screen.getByText('Download File'));
+    expect(createdLinks[createdLinks.length - 1].download).toMatch(/\.csv$/);
+
+    // Switch to JSON and download
+    fireEvent.click(screen.getByRole('radio', { name: /json/i }));
+    fireEvent.click(screen.getByText('Download File'));
+    expect(createdLinks[createdLinks.length - 1].download).toMatch(/\.json$/);
+
+    document.createElement.mockRestore();
   });
 });

--- a/src/components/modals/ExportBoardModal.jsx
+++ b/src/components/modals/ExportBoardModal.jsx
@@ -1,8 +1,15 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Clipboard } from 'react-feather';
+import { Clipboard, Download, FileText, AlignLeft, Grid, Code } from 'react-feather';
 import { useBoardContext, DEFAULT_BOARD_TITLE } from '../../context/BoardContext';
 import { useNotification } from '../../context/NotificationContext';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
+
+const FORMAT_OPTIONS = [
+  { value: 'markdown', label: 'Markdown', icon: FileText, ext: '.md' },
+  { value: 'plaintext', label: 'Plain Text', icon: AlignLeft, ext: '.txt' },
+  { value: 'csv', label: 'CSV', icon: Grid, ext: '.csv' },
+  { value: 'json', label: 'JSON', icon: Code, ext: '.json' },
+];
 
 const ExportBoardModal = ({ isOpen, onClose }) => {
   const [format, setFormat] = useState('markdown');
@@ -379,21 +386,89 @@ const ExportBoardModal = ({ isOpen, onClose }) => {
     return text;
   }, [getBoardStructure]);
 
+  const generateCsvExport = useCallback(() => {
+    const boardData = getBoardStructure();
+    const rows = [];
+
+    // CSV header
+    rows.push(['Column', 'Group', 'Card', 'Votes', 'Tags', 'Comments', 'Reactions']);
+
+    if (boardData.columns.length === 0) {
+      return rows.map(row => row.map(escapeCsvField).join(',')).join('\n');
+    }
+
+    boardData.columns.forEach(column => {
+      // Export grouped cards
+      if (column.groups && column.groups.length > 0) {
+        column.groups.forEach(group => {
+          // Add group row itself if it has votes/comments/reactions
+          if (group.votes > 0 || group.comments.length > 0 || group.reactions.length > 0) {
+            rows.push([
+              column.title,
+              group.name,
+              '',
+              String(group.votes),
+              '',
+              group.comments.join('; '),
+              group.reactions.map(r => `${r.emoji} (${r.count})`).join(', ')
+            ]);
+          }
+
+          // Add each card in the group
+          group.cards.forEach(card => {
+            rows.push([
+              column.title,
+              group.name,
+              card.content,
+              String(card.votes),
+              (card.tags || []).join(', '),
+              card.comments.join('; '),
+              card.reactions.map(r => `${r.emoji} (${r.count})`).join(', ')
+            ]);
+          });
+        });
+      }
+
+      // Export ungrouped cards
+      column.cards.forEach(card => {
+        rows.push([
+          column.title,
+          '',
+          card.content,
+          String(card.votes),
+          (card.tags || []).join(', '),
+          card.comments.join('; '),
+          card.reactions.map(r => `${r.emoji} (${r.count})`).join(', ')
+        ]);
+      });
+    });
+
+    return rows.map(row => row.map(escapeCsvField).join(',')).join('\n');
+  }, [getBoardStructure]);
+
+  const generateJsonExport = useCallback(() => {
+    const boardData = getBoardStructure();
+    return JSON.stringify(boardData, null, 2);
+  }, [getBoardStructure]);
+
   // Generate export content when modal is opened or format changes
   useEffect(() => {
     if (isOpen) {
       try {
-        if (format === 'markdown') {
-          setExportedContent(generateMarkdownExport());
-        } else {
-          setExportedContent(generatePlainTextExport());
-        }
+        const generators = {
+          markdown: generateMarkdownExport,
+          plaintext: generatePlainTextExport,
+          csv: generateCsvExport,
+          json: generateJsonExport,
+        };
+        const generator = generators[format];
+        setExportedContent(generator ? generator() : generateMarkdownExport());
       } catch {
         // Error generating export - silent fallback
         setExportedContent('Error generating export. Please try again.');
       }
     }
-  }, [isOpen, format, columns, boardTitle, generateMarkdownExport, generatePlainTextExport]);
+  }, [isOpen, format, columns, boardTitle, generateMarkdownExport, generatePlainTextExport, generateCsvExport, generateJsonExport]);
 
   /**
    * Note on column ordering and card grouping:
@@ -423,44 +498,63 @@ const ExportBoardModal = ({ isOpen, onClose }) => {
       });
   };
 
+  const downloadFile = () => {
+    const formatOption = FORMAT_OPTIONS.find(f => f.value === format);
+    const ext = formatOption ? formatOption.ext : '.txt';
+    const title = (boardTitle || DEFAULT_BOARD_TITLE).replace(/[^a-z0-9]/gi, '-').toLowerCase();
+    const filename = `${title}${ext}`;
+
+    const mimeTypes = {
+      markdown: 'text/markdown',
+      plaintext: 'text/plain',
+      csv: 'text/csv',
+      json: 'application/json',
+    };
+
+    const blob = new Blob([exportedContent], { type: mimeTypes[format] || 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+
+    showNotification(`Downloaded ${filename}`);
+  };
+
   if (!isOpen) {
     return null;
   }
 
   return (
     <div className="modal-overlay" role="presentation">
-      <div ref={modalRef} className="modal-container" role="dialog" aria-modal="true" aria-labelledby="export-board-title">
+      <div ref={modalRef} className="modal-container export-modal" role="dialog" aria-modal="true" aria-labelledby="export-board-title">
         <div className="modal-header">
           <h2 id="export-board-title">Export Board</h2>
           <button className="close-button" onClick={onClose} aria-label="Close">&times;</button>
         </div>
         <div className="modal-body">
           <div className="format-selector">
-            <div className="format-option">
-              <label className={`format-label ${format === 'markdown' ? 'selected' : ''}`}>
-                <input
-                  type="radio"
-                  value="markdown"
-                  checked={format === 'markdown'}
-                  onChange={() => setFormat('markdown')}
-                  className="format-radio"
-                />
-                <span className="format-name">Markdown</span>
-              </label>
-            </div>
-
-            <div className="format-option">
-              <label className={`format-label ${format === 'plaintext' ? 'selected' : ''}`}>
-                <input
-                  type="radio"
-                  value="plaintext"
-                  checked={format === 'plaintext'}
-                  onChange={() => setFormat('plaintext')}
-                  className="format-radio"
-                />
-                <span className="format-name">Plain Text</span>
-              </label>
-            </div>
+            {FORMAT_OPTIONS.map(opt => {
+              const Icon = opt.icon;
+              return (
+                <div className="format-option" key={opt.value}>
+                  <label className={`format-label ${format === opt.value ? 'selected' : ''}`}>
+                    <input
+                      type="radio"
+                      value={opt.value}
+                      checked={format === opt.value}
+                      onChange={() => setFormat(opt.value)}
+                      className="format-radio"
+                    />
+                    <Icon size={16} className="format-icon" />
+                    <span className="format-name">{opt.label}</span>
+                  </label>
+                </div>
+              );
+            })}
           </div>
           <div className="export-preview">
             <textarea
@@ -479,6 +573,13 @@ const ExportBoardModal = ({ isOpen, onClose }) => {
             Copy to Clipboard
           </button>
           <button
+            className="primary-button export-download-button"
+            onClick={downloadFile}
+          >
+            <Download size={16} />
+            Download File
+          </button>
+          <button
             className="secondary-button"
             onClick={onClose}
           >
@@ -489,5 +590,20 @@ const ExportBoardModal = ({ isOpen, onClose }) => {
     </div>
   );
 };
+
+/**
+ * Escape a CSV field value, wrapping in quotes if it contains
+ * commas, quotes, or newlines.
+ */
+function escapeCsvField(value) {
+  if (value == null) {
+    return '';
+  }
+  const str = String(value);
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
 
 export default ExportBoardModal;

--- a/src/styles/components/modals.css
+++ b/src/styles/components/modals.css
@@ -86,7 +86,7 @@
 .primary-button {
   background-color: var(--accent);
   color: var(--text-on-accent);
-  border: none;
+  border: 1px solid transparent;
   padding: var(--space-sm) var(--space-lg);
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -126,31 +126,39 @@
   border-color: var(--border-color);
 }
 
+/* Export modal */
+.export-modal {
+  max-width: 650px;
+}
+
 /* Export modal - format selector */
 .format-selector {
   display: flex;
-  justify-content: center;
-  margin-bottom: var(--space-lg);
-  gap: var(--space-md);
+  justify-content: space-between;
+  width: 100%;
+  gap: var(--space-sm);
 }
 
 .format-option {
-  width: 200px;
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .format-label {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-sm) var(--space-md);
+  gap: var(--space-xs);
+  padding: var(--space-sm);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   background-color: var(--bg-color);
   cursor: pointer;
   transition: all var(--transition-speed) var(--transition-ease);
   text-align: center;
+  height: 100%; /* Ensure they all match height if text wraps */
+  width: 100%;
 }
-
 .format-label:hover {
   background-color: var(--card-bg);
 }
@@ -167,9 +175,18 @@
   height: 0;
 }
 
+.format-icon {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.format-label.selected .format-icon {
+  color: var(--accent);
+}
+
 .format-name {
   font-weight: 500;
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-sm);
   color: var(--text-color);
   text-align: center;
 }
@@ -195,6 +212,18 @@
   white-space: pre;
   overflow: auto;
   box-shadow: none;
+}
+
+/* Export modal - download button */
+.export-download-button {
+  background-color: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+.export-download-button:hover {
+  background-color: var(--accent-transparent-lighter);
+  color: var(--accent);
 }
 
 /* Vote Limit Modal */
@@ -333,18 +362,19 @@
     justify-content: center;
   }
 
+  }
+
+@media (max-width: 480px) {
   .format-selector {
-    flex-direction: column;
-    align-items: center;
+    flex-wrap: wrap;
   }
 
   .format-option {
-    width: 100%;
-    max-width: 280px;
+    flex: 1 1 calc(50% - var(--space-sm));
+    min-width: 0;
   }
 
   .format-label {
-    padding: var(--space-md);
-    margin-bottom: var(--space-xs);
+    padding: var(--space-sm);
   }
 }


### PR DESCRIPTION
## Summary

- Expands the Export Board modal to support **4 formats**: Markdown, Plain Text, CSV, and JSON
- Adds **file download** in addition to copy-to-clipboard, with correct MIME types and extensions (`.md`, `.txt`, `.csv`, `.json`)
- Polishes the export modal UI with icon-labeled format buttons and an outline-style download button

## Details

### New Export Formats
- **CSV**: Flat table with columns: Column, Group, Card, Votes, Tags, Comments, Reactions. Proper field escaping for commas, quotes, and newlines. Ideal for spreadsheet import.
- **JSON**: Full board data structure export (title, columns, groups, cards with votes/tags/comments/reactions). Pretty-printed with 2-space indent. Ideal for programmatic use or re-import.

### Download Support
- New "Download File" button alongside "Copy to Clipboard"
- Generates filename from board title with correct extension
- Uses Blob + `URL.createObjectURL` for browser-native download
- Shows notification on successful download

### UI Polish
- Format selector updated to 4 evenly-sized buttons with `react-feather` icons (FileText, AlignLeft, Grid, Code)
- Download button uses outline style to visually differentiate from primary copy button
- Primary button border matched to prevent height mismatch with outline buttons
- Responsive: wraps to 2x2 grid on small screens

### Tests
- 16 tests total (up from 2) covering:
  - CSV header generation, field escaping, grouped/ungrouped cards, reactions
  - JSON validity, complete structure, comments/reactions, tags
  - Format selector rendering, default state, button visibility
  - Clipboard API integration
  - Download blob creation and file extension correctness

Closes #71