### PR TITLE
Auto-configure Big Orca template to skip setup wizard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -100,7 +100,8 @@ function AppContent() {
           columns: template.columns,
           templateName: template.name,
           user,
-          queryString: window.location.search
+          queryString: window.location.search,
+          ...(template.defaultSettings && { settingsOverrides: template.defaultSettings })
         })
           .then(newBoardId => {
             handleOpenBoard(newBoardId);

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -93,6 +93,21 @@ vi.mock('./data/boardTemplates', () => ({
       columns: ['Topics', 'Discussing', 'Done'],
       icon: '☕',
       tags: ['discussion', 'meeting', 'agenda']
+    },
+    {
+      id: 'big-orca',
+      name: 'Big Orca',
+      description: 'Comprehensive retro covering feelings, commitments, and improvements',
+      columns: ['Good stuff', 'Bad stuff', 'Feelings', 'Improvements', 'Past commitments', 'New commitments'],
+      icon: '🐋',
+      tags: ['retrospective', 'team', 'commitments', 'feelings'],
+      skipWizard: true,
+      defaultSettings: {
+        retrospectiveMode: false,
+        showDisplayNames: false,
+        actionItemsEnabled: false,
+        workflowPhase: 'HEALTH_CHECK'
+      }
     }
   ]
 }));
@@ -209,5 +224,42 @@ describe('App Component', () => {
 
     // Dashboard should NOT be rendered
     expect(screen.queryByTestId('dashboard')).not.toBeInTheDocument();
+  });
+
+  test('passes settingsOverrides when template has defaultSettings (big-orca)', async () => {
+    // Set URL with big-orca template param
+    delete window.location;
+    window.location = { ...originalLocation, search: '?template=big-orca', href: 'http://localhost/?template=big-orca' };
+
+    // Mock pushState so handleOpenBoard doesn't throw in jsdom
+    const pushStateSpy = vi.spyOn(window.history, 'pushState').mockImplementation(() => {});
+
+    const { createBoardFromTemplate } = await import('./utils/boardUtils');
+    const createBoardMock = vi.mocked(createBoardFromTemplate);
+
+    render(<App />);
+
+    // Wait for createBoardFromTemplate to have been called with settingsOverrides
+    await waitFor(() => {
+      expect(createBoardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          columns: ['Good stuff', 'Bad stuff', 'Feelings', 'Improvements', 'Past commitments', 'New commitments'],
+          templateName: 'Big Orca',
+          settingsOverrides: {
+            retrospectiveMode: false,
+            showDisplayNames: false,
+            actionItemsEnabled: false,
+            workflowPhase: 'HEALTH_CHECK'
+          }
+        })
+      );
+    }, { timeout: 2000 });
+
+    // After template board is created, the app should navigate to the board
+    await waitFor(() => {
+      expect(screen.getByTestId('board')).toBeInTheDocument();
+    }, { timeout: 2000 });
+
+    pushStateSpy.mockRestore();
   });
 });

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -105,11 +105,45 @@ function Dashboard({ onOpenBoard, darkMode, onToggleDarkMode }) {
   }, [recentBoards.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // When a template is selected, store it and open the setup wizard
-  const handleTemplateSelected = useCallback((templateColumns, templateName = null, templateTags = []) => {
-    setPendingTemplate({ columns: templateColumns, name: templateName, tags: templateTags });
+  // If the template has skipWizard, bypass the wizard and create the board directly
+  const handleTemplateSelected = useCallback((templateColumns, templateName = null, templateTags = [], templateObj = null) => {
+    const template = { columns: templateColumns, name: templateName, tags: templateTags };
+
+    if (templateObj?.skipWizard && templateObj?.defaultSettings) {
+      // Skip wizard — create board directly with template's default settings
+      const createDirectly = (currentUser) => {
+        createBoardFromTemplate({
+          columns: template.columns,
+          templateName: template.name,
+          user: currentUser,
+          queryString: window.location.search,
+          settingsOverrides: templateObj.defaultSettings
+        })
+          .then(newBoardId => {
+            setIsTemplateModalOpen(false);
+            onOpenBoard(newBoardId);
+          })
+          .catch(error => {
+            console.error('Error creating board:', error);
+          });
+      };
+
+      if (user) {
+        createDirectly(user);
+      } else {
+        signInAnonymously(auth)
+          .then(result => createDirectly(result.user))
+          .catch(error => {
+            console.error('Error signing in for template creation:', error);
+          });
+      }
+      return;
+    }
+
+    setPendingTemplate(template);
     setIsTemplateModalOpen(false);
     setIsWizardOpen(true);
-  }, []);
+  }, [user, onOpenBoard]);
 
   // When wizard is confirmed, create the board with the chosen settings
   const handleWizardConfirm = useCallback((wizardSettings) => {

--- a/src/components/Dashboard.test.jsx
+++ b/src/components/Dashboard.test.jsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi, describe, test, beforeEach, expect } from 'vitest';
 import { useRecentBoards } from '../hooks/useRecentBoards';
+import { createBoardFromTemplate } from '../utils/boardUtils';
 import Dashboard from './Dashboard';
 
 // Mock useRecentBoards hook
@@ -25,10 +26,18 @@ vi.mock('firebase/database', () => ({
   set: vi.fn().mockResolvedValue()
 }));
 
-// Mock NewBoardTemplateModal
+// Mock NewBoardTemplateModal — captures onSelectTemplate for test invocation
+let capturedOnSelectTemplate = null;
 vi.mock('./modals/NewBoardTemplateModal', () => ({
-  default: ({ isOpen }) =>
-    isOpen ? <div data-testid="template-modal">Template Modal</div> : null
+  default: ({ isOpen, onSelectTemplate }) => {
+    capturedOnSelectTemplate = onSelectTemplate;
+    return isOpen ? <div data-testid="template-modal">Template Modal</div> : null;
+  }
+}));
+
+// Mock boardUtils
+vi.mock('../utils/boardUtils', () => ({
+  createBoardFromTemplate: vi.fn(() => Promise.resolve('new-board-123'))
 }));
 
 describe('Dashboard Component', () => {
@@ -276,5 +285,75 @@ describe('Dashboard Component', () => {
     fireEvent.click(screen.getByText('Clear all'));
     expect(window.confirm).toHaveBeenCalled();
     expect(mockClearAll).not.toHaveBeenCalled();
+  });
+
+  test('skips wizard and creates board directly when template has skipWizard', async () => {
+    renderDashboard();
+
+    // Open template modal to capture onSelectTemplate
+    fireEvent.click(screen.getByText('New Board'));
+    expect(capturedOnSelectTemplate).toBeDefined();
+
+    // Simulate selecting a template with skipWizard and defaultSettings
+    const skipWizardTemplate = {
+      id: 'big-orca',
+      name: 'Big Orca',
+      columns: ['Good stuff', 'Bad stuff'],
+      tags: ['retrospective'],
+      skipWizard: true,
+      defaultSettings: {
+        retrospectiveMode: false,
+        showDisplayNames: false,
+        actionItemsEnabled: false,
+        workflowPhase: 'HEALTH_CHECK'
+      }
+    };
+
+    capturedOnSelectTemplate(
+      skipWizardTemplate.columns,
+      skipWizardTemplate.name,
+      skipWizardTemplate.tags,
+      skipWizardTemplate
+    );
+
+    // createBoardFromTemplate should be called directly with defaultSettings
+    await waitFor(() => {
+      expect(createBoardFromTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          columns: ['Good stuff', 'Bad stuff'],
+          templateName: 'Big Orca',
+          settingsOverrides: {
+            retrospectiveMode: false,
+            showDisplayNames: false,
+            actionItemsEnabled: false,
+            workflowPhase: 'HEALTH_CHECK'
+          }
+        })
+      );
+    });
+
+    // Board should be opened after creation
+    await waitFor(() => {
+      expect(mockOnOpenBoard).toHaveBeenCalledWith('new-board-123');
+    });
+  });
+
+  test('opens wizard normally when template does not have skipWizard', () => {
+    renderDashboard();
+
+    // Open template modal to capture onSelectTemplate
+    fireEvent.click(screen.getByText('New Board'));
+    expect(capturedOnSelectTemplate).toBeDefined();
+
+    // Simulate selecting a regular template (no skipWizard)
+    capturedOnSelectTemplate(
+      ['Topics', 'Discussing', 'Done'],
+      'Lean Coffee',
+      ['discussion'],
+      { id: 'lean-coffee', name: 'Lean Coffee', columns: ['Topics', 'Discussing', 'Done'], tags: ['discussion'] }
+    );
+
+    // createBoardFromTemplate should NOT be called (wizard should open instead)
+    expect(createBoardFromTemplate).not.toHaveBeenCalled();
   });
 });

--- a/src/components/modals/NewBoardTemplateModal.jsx
+++ b/src/components/modals/NewBoardTemplateModal.jsx
@@ -69,7 +69,7 @@ const NewBoardTemplateModal = ({ isOpen, onClose, onSelectTemplate }) => {
   const handleConfirm = () => {
     const template = BOARD_TEMPLATES.find(t => t.id === selectedTemplate);
     if (template) {
-      onSelectTemplate(template.columns, template.name, template.tags);
+      onSelectTemplate(template.columns, template.name, template.tags, template);
     }
   };
 

--- a/src/data/boardTemplates.js
+++ b/src/data/boardTemplates.js
@@ -1,3 +1,5 @@
+import { WORKFLOW_PHASES } from '../utils/workflowUtils';
+
 /**
  * Board template definitions for the template selection modal.
  * Each template defines the column structure for a new board.
@@ -9,6 +11,8 @@
  * @property {string[]} columns - Column names to create
  * @property {string} icon - Emoji icon for display
  * @property {string[]} tags - Searchable tags
+ * @property {boolean} [skipWizard] - If true, skip the setup wizard and use defaultSettings
+ * @property {Object} [defaultSettings] - Settings to apply when skipWizard is true
  */
 
 /** @type {BoardTemplate[]} */
@@ -251,7 +255,14 @@ const BOARD_TEMPLATES = [
     description: 'Comprehensive retro covering feelings, commitments, and improvements',
     columns: ['Good stuff', 'Bad stuff', 'Feelings', 'Improvements', 'Past commitments', 'New commitments'],
     icon: '🐋',
-    tags: ['retrospective', 'team', 'commitments', 'feelings']
+    tags: ['retrospective', 'team', 'commitments', 'feelings'],
+    skipWizard: true,
+    defaultSettings: {
+      retrospectiveMode: false,
+      showDisplayNames: false,
+      actionItemsEnabled: false,
+      workflowPhase: WORKFLOW_PHASES.HEALTH_CHECK
+    }
   }
 ];
 

--- a/src/data/boardTemplates.test.js
+++ b/src/data/boardTemplates.test.js
@@ -85,6 +85,20 @@ describe('BOARD_TEMPLATES', () => {
     expect(bigOrcaTemplate.tags).toContain('team');
   });
 
+  it('big-orca template should have skipWizard enabled', () => {
+    const bigOrcaTemplate = BOARD_TEMPLATES.find((t) => t.id === 'big-orca');
+    expect(bigOrcaTemplate.skipWizard).toBe(true);
+  });
+
+  it('big-orca template should have correct defaultSettings', () => {
+    const bigOrcaTemplate = BOARD_TEMPLATES.find((t) => t.id === 'big-orca');
+    expect(bigOrcaTemplate.defaultSettings).toBeDefined();
+    expect(bigOrcaTemplate.defaultSettings.retrospectiveMode).toBe(false);
+    expect(bigOrcaTemplate.defaultSettings.showDisplayNames).toBe(false);
+    expect(bigOrcaTemplate.defaultSettings.actionItemsEnabled).toBe(false);
+    expect(bigOrcaTemplate.defaultSettings.workflowPhase).toBe('HEALTH_CHECK');
+  });
+
   it('should support findTemplateBySlug lookup by id', () => {
     const findTemplateBySlug = (slug) => BOARD_TEMPLATES.find((t) => t.id === slug);
 


### PR DESCRIPTION
## Summary

- When the Big Orca template is used (via `?template=big-orca` URL or the template selection UI), it now **skips the setup wizard** and auto-configures the board with: kanban mode, display names disabled, action items disabled, and health check enabled
- Teams can start a new board by just clicking a link to `?template=big-orca` without any configuration

## Changes

### Template definition (`boardTemplates.js`)
- Added `skipWizard: true` and `defaultSettings` to the Big Orca template
- `defaultSettings` sets: `retrospectiveMode: false`, `showDisplayNames: false`, `actionItemsEnabled: false`, `workflowPhase: HEALTH_CHECK`

### URL path (`App.jsx`)
- When creating a board from a `?template=` URL, now passes `template.defaultSettings` as `settingsOverrides` to `createBoardFromTemplate()`

### Dashboard UI path (`Dashboard.jsx`)
- When a template with `skipWizard: true` is selected from the template modal, bypasses the setup wizard and creates the board directly with the template's `defaultSettings`

### Template modal (`NewBoardTemplateModal.jsx`)
- Now passes the full template object as a 4th argument to `onSelectTemplate`, enabling Dashboard to check `skipWizard` and `defaultSettings`

## Design

The `skipWizard` and `defaultSettings` fields are **optional** on templates — all other templates continue to work exactly as before (showing the setup wizard). This makes the feature easily extensible to other templates in the future.

## Tests

- 5 new tests added across `boardTemplates.test.js`, `App.test.jsx`, and `Dashboard.test.jsx`
- All 1066 tests pass, lint clean, build succeeds