### PR TITLE
Fix offline banner flash on initial page load

### DIFF
--- a/src/hooks/useConnectionStatus.js
+++ b/src/hooks/useConnectionStatus.js
@@ -1,5 +1,5 @@
 import { ref, onValue } from 'firebase/database';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { database } from '../utils/firebase';
 
 /**
@@ -7,18 +7,29 @@ import { database } from '../utils/firebase';
  *
  * Uses the special `.info/connected` path that Firebase provides.
  * Returns `true` when connected, `false` when disconnected.
- * Starts as `true` to avoid a flash of the offline indicator on mount.
+ * Starts as `true` and ignores the initial `false` from Firebase's
+ * `.info/connected` handshake to avoid flashing the offline banner on load.
  *
  * @returns {{ isOnline: boolean }}
  */
 export const useConnectionStatus = () => {
   const [isOnline, setIsOnline] = useState(true);
+  const hasConnected = useRef(false);
 
   useEffect(() => {
     const connectedRef = ref(database, '.info/connected');
 
     const unsubscribe = onValue(connectedRef, (snapshot) => {
-      setIsOnline(snapshot.val() === true);
+      const connected = snapshot.val() === true;
+
+      if (connected) {
+        hasConnected.current = true;
+        setIsOnline(true);
+      } else if (hasConnected.current) {
+        // Only show offline after we've confirmed a real connection first,
+        // so the initial false→true handshake doesn't flash the banner
+        setIsOnline(false);
+      }
     });
 
     return () => unsubscribe();

--- a/src/hooks/useConnectionStatus.test.js
+++ b/src/hooks/useConnectionStatus.test.js
@@ -66,7 +66,7 @@ describe('useConnectionStatus', () => {
     expect(result.current.isOnline).toBe(true);
   });
 
-  it('sets isOnline to false when snapshot.val() returns false', () => {
+  it('ignores initial false from Firebase handshake (prevents flash)', () => {
     const unsubscribeMock = vi.fn();
     let capturedCallback;
 
@@ -77,15 +77,16 @@ describe('useConnectionStatus', () => {
 
     const { result } = renderHook(() => useConnectionStatus());
 
-    // Simulate Firebase snapshot with false value
+    // Firebase fires false before connection is established
     act(() => {
       capturedCallback({ val: () => false });
     });
 
-    expect(result.current.isOnline).toBe(false);
+    // Should still be true — initial false is ignored to prevent flash
+    expect(result.current.isOnline).toBe(true);
   });
 
-  it('transitions from online to offline', () => {
+  it('sets isOnline to false after a prior connection was established', () => {
     const unsubscribeMock = vi.fn();
     let capturedCallback;
 
@@ -96,21 +97,49 @@ describe('useConnectionStatus', () => {
 
     const { result } = renderHook(() => useConnectionStatus());
 
-    // Start online
+    // First connect
+    act(() => {
+      capturedCallback({ val: () => true });
+    });
+    expect(result.current.isOnline).toBe(true);
+
+    // Then disconnect
+    act(() => {
+      capturedCallback({ val: () => false });
+    });
+    expect(result.current.isOnline).toBe(false);
+  });
+
+  it('transitions from online to offline and back', () => {
+    const unsubscribeMock = vi.fn();
+    let capturedCallback;
+
+    onValue.mockImplementation((refArg, callback) => {
+      capturedCallback = callback;
+      return unsubscribeMock;
+    });
+
+    const { result } = renderHook(() => useConnectionStatus());
+
+    // Start online (default)
+    expect(result.current.isOnline).toBe(true);
+
+    // Establish real connection
+    act(() => {
+      capturedCallback({ val: () => true });
+    });
     expect(result.current.isOnline).toBe(true);
 
     // Go offline
     act(() => {
       capturedCallback({ val: () => false });
     });
-
     expect(result.current.isOnline).toBe(false);
 
     // Go back online
     act(() => {
       capturedCallback({ val: () => true });
     });
-
     expect(result.current.isOnline).toBe(true);
   });
 
@@ -159,17 +188,19 @@ describe('useConnectionStatus', () => {
 
     const { result } = renderHook(() => useConnectionStatus());
 
-    // Rapid state changes
+    // Initial false is ignored
     act(() => {
       capturedCallback({ val: () => false });
     });
-    expect(result.current.isOnline).toBe(false);
+    expect(result.current.isOnline).toBe(true);
 
+    // First true establishes connection
     act(() => {
       capturedCallback({ val: () => true });
     });
     expect(result.current.isOnline).toBe(true);
 
+    // Now false is honored
     act(() => {
       capturedCallback({ val: () => false });
     });


### PR DESCRIPTION
## Summary

- **Fix**: Prevent the yellow "You're offline" banner from briefly flashing when the site first loads
- **Root cause**: Firebase's `.info/connected` always fires `false` before the connection is established, then fires `true` — this initial `false` was triggering the offline banner
- **Solution**: Track whether a real connection has been established via a `useRef`. Only transition to offline state after a prior successful connection, so the initial `false→true` handshake is invisible to the user

## Changes

- `src/hooks/useConnectionStatus.js` — Added `hasConnected` ref to ignore initial `false` from Firebase handshake
- `src/hooks/useConnectionStatus.test.js` — Updated existing tests and added new test for the handshake-ignore behavior (10 tests total, all passing)

## Testing

- All 1067 tests pass
- Lint clean
- Build succeeds