### PR TITLE
Restore total votes remaining indicator to board header

### DIFF
--- a/src/components/BoardHeader.jsx
+++ b/src/components/BoardHeader.jsx
@@ -1,5 +1,6 @@
 import { Home, Maximize2, Search } from 'react-feather';
 import { DEFAULT_BOARD_TITLE } from '../context/BoardContext';
+import TotalVoteCounter from './TotalVoteCounter';
 import UserCounter from './UserCounter';
 /**
  * Board header with title input, user/vote counters, and share/export buttons.
@@ -53,6 +54,7 @@ const BoardHeader = ({ boardTitle, handleBoardTitleChange, handleBoardTitleBlur,
     )}
     <div className="action-buttons">
       <UserCounter />
+      <TotalVoteCounter />
     </div>
 
   </div>


### PR DESCRIPTION
Restores the at-a-glance "total votes remaining" indicator that used to appear in the board header during the voting phase of a retrospective.

### What changed
The `TotalVoteCounter` component (and its `useVoteCounterVisibility` hook + tests) was still in the codebase but had been unwired from `BoardHeader.jsx` during the "Polish board view UI: declutter header" change (commit e0b27b7), which removed it as "redundant with per-card counters". In practice the team-wide remaining count was useful during voting, so this PR re-imports it and renders it next to `UserCounter` in the header action-buttons row.

### Why this is safe
- No new code — just re-wiring an existing, already-tested component.
- The component self-gates on `votingEnabled && retrospectiveMode && areInteractionsVisible(workflowPhase) && activeUsers`, so it only appears during the interactions/voting phase. Outside that phase, the header looks identical to today.
- 2 lines added, 0 removed.

### Verification
- `npm run lint` ✓
- `npm test` — 1319/1319 passing ✓ (includes the 8 existing `TotalVoteCounter` tests and 6 `useVoteCounterVisibility` tests)
- `npm run build` ✓

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>