### PR TITLE
Board series: link boards into a chain you can page back through

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,7 @@ Boards can be linked into an ordered chain so users can page back to earlier boa
 
 - Pointers live on the board node in Firebase (shared, not localStorage): `boards/{boardId}/previousBoardId` and `nextBoardId`. Linking A→B sets `B.previousBoardId = A` and `A.nextBoardId = B` (doubly-linked, adjacent paging only).
 - Operations live in `src/hooks/useBoardSeries.js`: `startNextBoard` (clones the current board's column structure + settings with empty cards, links pointers, returns the new ID), `linkToPreviousBoard`, `unlinkFromSeries`. Wired through `BoardContext`.
+- **Chain integrity**: replacing an existing link detaches the displaced neighbour's reciprocal pointer (no dangling back-references); `linkToPreviousBoard` walks the target's predecessor chain (bounded) and refuses links that would create a cycle; `unlinkFromSeries` splices the two neighbours together when removing a middle board.
 - `BoardSeriesPager` (in the header via `BoardHeader`) renders `← Previous / Next →`, shown only when a pointer exists. Navigation reuses App's `?board=` mechanism (`handleOpenBoard`).
 - **Gotcha**: `BoardGate` in `App.jsx` is keyed on `key={activeBoardId}` so navigating board→board remounts `BoardProvider` and re-subscribes (the provider does not resync `initialBoardId` on its own).
 - Entry points: "Start next board" and "Link to previous board" in the Settings panel's Share & Export tab; the latter opens `LinkPreviousBoardModal` (recent-boards picker or paste a URL/ID, parsed by `utils/boardLink.js`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,8 @@ boards/{boardId}/
   title: string
   created: timestamp
   owner: string (uid)
+  previousBoardId?: string (board series: link to the predecessor board)
+  nextBoardId?: string     (board series: link to the successor board)
   columns/{columnId}/
     title: string
     cards/{cardId}/
@@ -264,6 +266,16 @@ HEALTH_CHECK → HEALTH_CHECK_RESULTS → CREATION → GROUPING → INTERACTIONS
 Defined in `workflowUtils.js` as the `WORKFLOW_PHASES` enum. Each phase restricts what actions are available (e.g., voting only in INTERACTIONS, card creation only in CREATION). Phase permission logic is in the `canPerformAction()` and related functions in `workflowUtils.js`.
 
 The `INTERACTION_REVEAL` phase uses reveal logic in `retrospectiveModeUtils.js` to progressively show votes/reactions.
+
+## Board Series
+
+Boards can be linked into an ordered chain so users can page back to earlier boards (e.g. to review a previous retro's commitments). Works in both kanban and retrospective formats — it links *boards*, independent of workflow phases.
+
+- Pointers live on the board node in Firebase (shared, not localStorage): `boards/{boardId}/previousBoardId` and `nextBoardId`. Linking A→B sets `B.previousBoardId = A` and `A.nextBoardId = B` (doubly-linked, adjacent paging only).
+- Operations live in `src/hooks/useBoardSeries.js`: `startNextBoard` (clones the current board's column structure + settings with empty cards, links pointers, returns the new ID), `linkToPreviousBoard`, `unlinkFromSeries`. Wired through `BoardContext`.
+- `BoardSeriesPager` (in the header via `BoardHeader`) renders `← Previous / Next →`, shown only when a pointer exists. Navigation reuses App's `?board=` mechanism (`handleOpenBoard`).
+- **Gotcha**: `BoardGate` in `App.jsx` is keyed on `key={activeBoardId}` so navigating board→board remounts `BoardProvider` and re-subscribes (the provider does not resync `initialBoardId` on its own).
+- Entry points: "Start next board" and "Link to previous board" in the Settings panel's Share & Export tab; the latter opens `LinkPreviousBoardModal` (recent-boards picker or paste a URL/ID, parsed by `utils/boardLink.js`).
 
 ## Styling
 
@@ -361,7 +373,7 @@ npm run lint:check # Same as lint (alias)
 
 ## Known Issues & Technical Debt
 
-1. **Firebase config is hardcoded** in `src/utils/firebase.js` — not using environment variables. The project is "big-orca" on Firebase.
+1. **Firebase config comes from env vars** in `src/utils/firebase.js` (`VITE_FIREBASE_*`) and **throws if any are missing** — local `npm run dev`/`test:e2e` need a `.env` (copy `.env.example`); CI/deploy inject them as secrets. The project is "big-orca" on Firebase. (The web config values are public client config, shipped in the deployed bundle.)
 2. **No TypeScript** — all files are `.jsx`. No type checking beyond ESLint.
 3. **No routing library** — board ID is managed via query params manually.
 

--- a/e2e/board-series.spec.js
+++ b/e2e/board-series.spec.js
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Helper: create a board via the template modal + setup wizard UI flow.
+ * Waits for auth, clicks New Board, selects default template, clicks through
+ * the setup wizard, then waits for the board view to appear.
+ *
+ * (Mirrors the helper in board.spec.js — e2e specs are self-contained.)
+ */
+async function createBoardViaModal(page) {
+  await page.goto('/');
+
+  await expect(page.getByRole('button', { name: /new board/i })).toBeVisible();
+
+  let boardLoaded = false;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    await page.getByRole('button', { name: /new board/i }).click();
+
+    const modalHeading = page.getByRole('heading', { name: /choose a board template/i });
+    await expect(modalHeading).toBeVisible({ timeout: 3000 });
+
+    await page.getByRole('button', { name: /create board/i }).click();
+
+    const wizardHeading = page.getByRole('heading', { name: /set up your board/i });
+    await expect(wizardHeading).toBeVisible({ timeout: 3000 });
+
+    await page.locator('.wizard-modal').getByRole('button', { name: /create board/i }).click();
+
+    try {
+      await expect(page.getByLabel('Board title')).toBeVisible({ timeout: 8000 });
+      boardLoaded = true;
+      break;
+    } catch {
+      const wizardCloseBtn = page.locator('.wizard-modal').getByRole('button', { name: /close setup wizard/i });
+      if (await wizardCloseBtn.isVisible().catch(() => false)) {
+        await wizardCloseBtn.click();
+      }
+      const cancelBtn = page.getByRole('button', { name: /cancel/i });
+      if (await cancelBtn.isVisible().catch(() => false)) {
+        await cancelBtn.click();
+      }
+      await page.waitForTimeout(3000);
+    }
+  }
+
+  if (!boardLoaded) {
+    throw new Error('Failed to create board after 5 attempts — Firebase auth may not be working');
+  }
+}
+
+/** Extract the ?board= id from a URL string. */
+function boardIdFromUrl(url) {
+  const match = url.match(/[?&]board=([^&]+)/);
+  return match ? match[1] : null;
+}
+
+test.describe('Board series', () => {
+  test('start next board links boards and lets you page back and forth', async ({ page }) => {
+    // Auto-accept the confirm() that appears only if a board already has a next link.
+    page.on('dialog', dialog => dialog.accept());
+
+    await createBoardViaModal(page);
+    await expect(page).toHaveURL(/[?&]board=/);
+
+    const firstBoardId = boardIdFromUrl(page.url());
+    expect(firstBoardId).toBeTruthy();
+
+    // Open settings → Share & Export tab → Start next board.
+    await page.getByRole('button', { name: /board settings/i }).click();
+    await expect(page.getByRole('heading', { name: /board settings/i })).toBeVisible();
+    await page.getByRole('tab', { name: /share & export/i }).click();
+
+    const startNextBtn = page.getByRole('button', { name: /start next board/i });
+    await expect(startNextBtn).toBeVisible();
+    await startNextBtn.click();
+
+    // We should navigate to a NEW board with a different id.
+    await expect
+      .poll(() => boardIdFromUrl(page.url()), { timeout: 15000 })
+      .not.toBe(firstBoardId);
+    const secondBoardId = boardIdFromUrl(page.url());
+    expect(secondBoardId).toBeTruthy();
+
+    // The new board is the successor, so it shows a "Previous" pager control.
+    const prevBtn = page.getByRole('button', { name: /previous board in series/i });
+    await expect(prevBtn).toBeVisible({ timeout: 10000 });
+
+    // Page back to the first board.
+    await prevBtn.click();
+    await expect
+      .poll(() => boardIdFromUrl(page.url()), { timeout: 15000 })
+      .toBe(firstBoardId);
+
+    // The first board is the predecessor, so it shows a "Next" pager control.
+    await expect(page.getByRole('button', { name: /next board in series/i })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('link to previous board via paste shows the previous pager', async ({ page }) => {
+    page.on('dialog', dialog => dialog.accept());
+
+    // Create a first board to be the "previous" board, remember its id, then leave it.
+    await createBoardViaModal(page);
+    await expect(page).toHaveURL(/[?&]board=/);
+    const previousBoardId = boardIdFromUrl(page.url());
+    expect(previousBoardId).toBeTruthy();
+
+    // Create a second, independent board.
+    await createBoardViaModal(page);
+    await expect(page).toHaveURL(/[?&]board=/);
+    const currentBoardId = boardIdFromUrl(page.url());
+    expect(currentBoardId).not.toBe(previousBoardId);
+
+    // Open settings → Share & Export → Link to previous board.
+    await page.getByRole('button', { name: /board settings/i }).click();
+    await expect(page.getByRole('heading', { name: /board settings/i })).toBeVisible();
+    await page.getByRole('tab', { name: /share & export/i }).click();
+    await page.getByRole('button', { name: /link to previous board/i }).click();
+
+    // The link modal appears — paste the previous board id and link.
+    await expect(page.getByRole('heading', { name: /link to previous board/i })).toBeVisible();
+    await page.getByLabel(/paste a board link or id/i).fill(previousBoardId);
+    await page.getByRole('button', { name: /link board/i }).click();
+
+    // Back on the current board, the "Previous" pager should now appear.
+    await expect(page.getByRole('button', { name: /previous board in series/i })).toBeVisible({ timeout: 10000 });
+
+    // And paging back lands on the previous board.
+    await page.getByRole('button', { name: /previous board in series/i }).click();
+    await expect
+      .poll(() => boardIdFromUrl(page.url()), { timeout: 15000 })
+      .toBe(previousBoardId);
+  });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -137,7 +137,7 @@ function AppContent() {
         </a>
       )}
       {activeBoardId ? (
-        <BoardGate boardId={activeBoardId} onGoHome={handleGoHome} />
+        <BoardGate key={activeBoardId} boardId={activeBoardId} onGoHome={handleGoHome} onOpenBoard={handleOpenBoard} />
       ) : (
         <DashboardGate onOpenBoard={handleOpenBoard} />
       )}
@@ -162,11 +162,11 @@ function AppContent() {
  * Wraps the Board in a BoardProvider and passes the boardId + goHome handler.
  * BoardProvider handles Firebase subscription; Board handles rendering.
  */
-function BoardGate({ boardId, onGoHome }) {
+function BoardGate({ boardId, onGoHome, onOpenBoard }) {
   return (
     <DndProvider backend={HTML5Backend}>
       <BoardProvider initialBoardId={boardId}>
-        <BoardWithTracking onGoHome={onGoHome} />
+        <BoardWithTracking onGoHome={onGoHome} onOpenBoard={onOpenBoard} />
       </BoardProvider>
     </DndProvider>
   );
@@ -175,7 +175,7 @@ function BoardGate({ boardId, onGoHome }) {
 /**
  * Wrapper that tracks board visits in localStorage once board data loads.
  */
-function BoardWithTracking({ onGoHome }) {
+function BoardWithTracking({ onGoHome, onOpenBoard }) {
   const { boardId, boardTitle, columns } = useBoardContext();
   const { addBoard } = useRecentBoards();
 
@@ -190,7 +190,7 @@ function BoardWithTracking({ onGoHome }) {
     }
   }, [boardId, boardTitle, columns, addBoard]);
 
-  return <Board onGoHome={onGoHome} />;
+  return <Board onGoHome={onGoHome} onNavigateToBoard={onOpenBoard} />;
 }
 
 /**

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -202,7 +202,7 @@ function Board({ onGoHome, onNavigateToBoard }) {
 
   // Detach this board from its series
   const handleUnlinkSeries = useCallback(async () => {
-    const proceed = window.confirm('Remove this board from its series?');
+    const proceed = window.confirm('Remove this board from its series? Its neighbouring boards will stay linked to each other.');
     if (!proceed) return;
     try {
       await unlinkFromSeries();

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -16,6 +16,7 @@ import FocusMode from './FocusMode';
 import HealthCheckVoting from './HealthCheckVoting';
 import CardDetailModal from './modals/CardDetailModal';
 import ExportBoardModal from './modals/ExportBoardModal';
+import LinkPreviousBoardModal from './modals/LinkPreviousBoardModal';
 import PollResults from './PollResults';
 import PollVoting from './PollVoting';
 import ProfileButton from './ProfileButton';
@@ -28,11 +29,12 @@ import WorkflowControls from './WorkflowControls';
  * Main Board component responsible for rendering and managing the kanban board.
  * Orchestrates board initialization, URL settings, and layout of header, columns, and modals.
  */
-function Board({ onGoHome }) {
+function Board({ onGoHome, onNavigateToBoard }) {
   const { showNotification } = useNotification();
   // State for modals
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
   const [isActionItemsPanelOpen, setIsActionItemsPanelOpen] = useState(false);
+  const [isLinkPreviousModalOpen, setIsLinkPreviousModalOpen] = useState(false);
 
   // State for card detail modal
   const [expandedCard, setExpandedCard] = useState(null);
@@ -81,7 +83,12 @@ function Board({ onGoHome }) {
     setBoardBackground,
     setCustomBackground,
     customBackgroundSize,
-    setCustomBackgroundSize
+    setCustomBackgroundSize,
+    previousBoardId,
+    nextBoardId,
+    startNextBoard,
+    linkToPreviousBoard,
+    unlinkFromSeries
   } = useBoardContext();
 
   // Search state
@@ -174,6 +181,37 @@ function Board({ onGoHome }) {
     showNotification('Preparing board export...');
   };
 
+  // Create the next board in the series and navigate to it
+  const handleStartNextBoard = useCallback(async () => {
+    if (nextBoardId) {
+      const proceed = window.confirm(
+        'This board already links to a next board. Starting a new one will replace that link. Continue?'
+      );
+      if (!proceed) return;
+    }
+    try {
+      const newBoardId = await startNextBoard();
+      if (newBoardId && onNavigateToBoard) {
+        showNotification('Started next board in series');
+        onNavigateToBoard(newBoardId);
+      }
+    } catch {
+      showNotification('Could not start the next board');
+    }
+  }, [nextBoardId, startNextBoard, onNavigateToBoard, showNotification]);
+
+  // Detach this board from its series
+  const handleUnlinkSeries = useCallback(async () => {
+    const proceed = window.confirm('Remove this board from its series?');
+    if (!proceed) return;
+    try {
+      await unlinkFromSeries();
+      showNotification('Removed from series');
+    } catch {
+      showNotification('Could not update the series');
+    }
+  }, [unlinkFromSeries, showNotification]);
+
   // Handle card expand for card detail modal
   const handleExpandCard = useCallback((cardId, columnId, options = {}) => {
     setExpandedCard({ cardId, columnId, ...options });
@@ -219,6 +257,9 @@ function Board({ onGoHome }) {
             onSearchOpen={searchFilter.openSearch}
             isSearchOpen={searchFilter.isOpen}
             onFocusModeEnter={focusMode.enter}
+            previousBoardId={previousBoardId}
+            nextBoardId={nextBoardId}
+            onNavigateToBoard={onNavigateToBoard}
           />
           <SettingsPanel
             handleStartHealthCheck={() => {
@@ -261,6 +302,20 @@ function Board({ onGoHome }) {
             setCustomBackground={setCustomBackground}
             customBackgroundSize={customBackgroundSize}
             setCustomBackgroundSize={setCustomBackgroundSize}
+            previousBoardId={previousBoardId}
+            nextBoardId={nextBoardId}
+            onStartNextBoard={() => {
+              setSettingsDropdownOpen(false);
+              handleStartNextBoard();
+            }}
+            onOpenLinkPrevious={() => {
+              setSettingsDropdownOpen(false);
+              setIsLinkPreviousModalOpen(true);
+            }}
+            onUnlinkSeries={() => {
+              setSettingsDropdownOpen(false);
+              handleUnlinkSeries();
+            }}
           >
             <ProfileButton
               showDisplayNames={showDisplayNames}
@@ -341,6 +396,13 @@ function Board({ onGoHome }) {
       <ActionItemsPanel
         isOpen={isActionItemsPanelOpen}
         onClose={() => setIsActionItemsPanelOpen(false)}
+      />
+
+      <LinkPreviousBoardModal
+        isOpen={isLinkPreviousModalOpen}
+        onClose={() => setIsLinkPreviousModalOpen(false)}
+        currentBoardId={boardId}
+        onLink={linkToPreviousBoard}
       />
 
       {/* Card Detail Modal */}

--- a/src/components/BoardHeader.jsx
+++ b/src/components/BoardHeader.jsx
@@ -1,5 +1,6 @@
 import { Home, Maximize2, Search } from 'react-feather';
 import { DEFAULT_BOARD_TITLE } from '../context/BoardContext';
+import BoardSeriesPager from './BoardSeriesPager';
 import TotalVoteCounter from './TotalVoteCounter';
 import UserCounter from './UserCounter';
 /**
@@ -10,7 +11,7 @@ import UserCounter from './UserCounter';
  * @param {Function} props.handleBoardTitleChange - Called on title input change
  * @param {Function} props.handleBoardTitleBlur - Called on title input blur (persists to Firebase)
  */
-const BoardHeader = ({ boardTitle, handleBoardTitleChange, handleBoardTitleBlur, onGoHome, onSearchOpen, isSearchOpen, onFocusModeEnter }) => (
+const BoardHeader = ({ boardTitle, handleBoardTitleChange, handleBoardTitleBlur, onGoHome, onSearchOpen, isSearchOpen, onFocusModeEnter, previousBoardId, nextBoardId, onNavigateToBoard }) => (
   <div className="board-title-container">
     {onGoHome && (
       <button
@@ -21,6 +22,13 @@ const BoardHeader = ({ boardTitle, handleBoardTitleChange, handleBoardTitleBlur,
       >
         <Home size={16} />
       </button>
+    )}
+    {onNavigateToBoard && (
+      <BoardSeriesPager
+        previousBoardId={previousBoardId}
+        nextBoardId={nextBoardId}
+        onNavigate={onNavigateToBoard}
+      />
     )}
     <input
       type="text"

--- a/src/components/BoardSeriesPager.jsx
+++ b/src/components/BoardSeriesPager.jsx
@@ -1,0 +1,48 @@
+import { ChevronLeft, ChevronRight } from 'react-feather';
+
+/**
+ * Pager for navigating between boards that are linked into a series.
+ *
+ * Renders a "Previous" and/or "Next" control depending on which links exist.
+ * Returns null when the board has no series neighbours, so it takes up no space
+ * on standalone boards.
+ *
+ * @param {Object} props
+ * @param {string|null} props.previousBoardId - ID of the previous board, if any
+ * @param {string|null} props.nextBoardId - ID of the next board, if any
+ * @param {Function} props.onNavigate - Called with a board ID to navigate to it
+ */
+const BoardSeriesPager = ({ previousBoardId, nextBoardId, onNavigate }) => {
+  if (!previousBoardId && !nextBoardId) return null;
+
+  return (
+    <div className="board-series-pager" role="group" aria-label="Board series navigation">
+      {previousBoardId && (
+        <button
+          type="button"
+          className="board-series-btn board-series-prev"
+          onClick={() => onNavigate(previousBoardId)}
+          title="Go to previous board in series"
+          aria-label="Previous board in series"
+        >
+          <ChevronLeft size={16} aria-hidden="true" />
+          <span className="board-series-btn-label">Previous</span>
+        </button>
+      )}
+      {nextBoardId && (
+        <button
+          type="button"
+          className="board-series-btn board-series-next"
+          onClick={() => onNavigate(nextBoardId)}
+          title="Go to next board in series"
+          aria-label="Next board in series"
+        >
+          <span className="board-series-btn-label">Next</span>
+          <ChevronRight size={16} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default BoardSeriesPager;

--- a/src/components/BoardSeriesPager.test.jsx
+++ b/src/components/BoardSeriesPager.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import BoardSeriesPager from './BoardSeriesPager';
+
+describe('BoardSeriesPager', () => {
+  it('renders nothing when there are no series links', () => {
+    const { container } = render(
+      <BoardSeriesPager previousBoardId={null} nextBoardId={null} onNavigate={() => {}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders only the Previous button when only a previous board exists', () => {
+    render(
+      <BoardSeriesPager previousBoardId="prev-1" nextBoardId={null} onNavigate={() => {}} />
+    );
+    expect(screen.getByRole('button', { name: /previous board in series/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /next board in series/i })).not.toBeInTheDocument();
+  });
+
+  it('renders only the Next button when only a next board exists', () => {
+    render(
+      <BoardSeriesPager previousBoardId={null} nextBoardId="next-1" onNavigate={() => {}} />
+    );
+    expect(screen.getByRole('button', { name: /next board in series/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /previous board in series/i })).not.toBeInTheDocument();
+  });
+
+  it('navigates to the previous board when Previous is clicked', () => {
+    const onNavigate = vi.fn();
+    render(
+      <BoardSeriesPager previousBoardId="prev-1" nextBoardId="next-1" onNavigate={onNavigate} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /previous board in series/i }));
+    expect(onNavigate).toHaveBeenCalledWith('prev-1');
+  });
+
+  it('navigates to the next board when Next is clicked', () => {
+    const onNavigate = vi.fn();
+    render(
+      <BoardSeriesPager previousBoardId="prev-1" nextBoardId="next-1" onNavigate={onNavigate} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /next board in series/i }));
+    expect(onNavigate).toHaveBeenCalledWith('next-1');
+  });
+});

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { ArrowDown, BarChart2, CheckSquare, ChevronRight, EyeOff, FileText, Link, Monitor, Moon, RotateCcw, Settings, Share2, Sliders, Sun, ThumbsUp, Users, Zap } from 'react-feather';
+import { ArrowDown, BarChart2, CheckSquare, ChevronRight, EyeOff, FileText, Layers, Link, Link2, Monitor, Moon, RotateCcw, Scissors, Settings, Share2, Sliders, Sun, ThumbsUp, Users, Zap } from 'react-feather';
 import { useNotification } from '../context/NotificationContext';
 import BackgroundPicker from './BackgroundPicker';
 import InsightsContent from './InsightsContent';
@@ -51,7 +51,12 @@ const SettingsPanel = ({
   customBackgroundCss,
   setCustomBackground,
   customBackgroundSize,
-  setCustomBackgroundSize
+  setCustomBackgroundSize,
+  previousBoardId,
+  nextBoardId,
+  onStartNextBoard,
+  onOpenLinkPrevious,
+  onUnlinkSeries
 }) => {
   const { showNotification } = useNotification();
   const [activeTab, setActiveTab] = useState('appearance');
@@ -518,6 +523,61 @@ const SettingsPanel = ({
                             {actionItemCount > 0 && <span className="action-items-count-badge">{actionItemCount}</span>}
                           </span>
                           <span className="settings-share-action-desc">View and manage action items</span>
+                        </div>
+                        <ChevronRight size={16} className="settings-share-action-chevron" aria-hidden="true" />
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                <div className="settings-divider" />
+
+                <div className="settings-section">
+                  <h4 className="settings-section-title">Board series</h4>
+                  <div className="settings-share-actions">
+                    <button
+                      className="settings-share-action-btn"
+                      onClick={() => {
+                        if (onStartNextBoard) onStartNextBoard();
+                      }}
+                    >
+                      <div className="settings-share-action-icon">
+                        <Layers size={20} aria-hidden="true" />
+                      </div>
+                      <div className="settings-share-action-text">
+                        <span className="settings-share-action-title">Start next board</span>
+                        <span className="settings-share-action-desc">Create the next board in this series and jump to it</span>
+                      </div>
+                      <ChevronRight size={16} className="settings-share-action-chevron" aria-hidden="true" />
+                    </button>
+                    <button
+                      className="settings-share-action-btn"
+                      onClick={() => {
+                        if (onOpenLinkPrevious) onOpenLinkPrevious();
+                      }}
+                    >
+                      <div className="settings-share-action-icon">
+                        <Link2 size={20} aria-hidden="true" />
+                      </div>
+                      <div className="settings-share-action-text">
+                        <span className="settings-share-action-title">Link to previous board</span>
+                        <span className="settings-share-action-desc">Connect an earlier board so you can page back to it</span>
+                      </div>
+                      <ChevronRight size={16} className="settings-share-action-chevron" aria-hidden="true" />
+                    </button>
+                    {(previousBoardId || nextBoardId) && (
+                      <button
+                        className="settings-share-action-btn"
+                        onClick={() => {
+                          if (onUnlinkSeries) onUnlinkSeries();
+                        }}
+                      >
+                        <div className="settings-share-action-icon">
+                          <Scissors size={20} aria-hidden="true" />
+                        </div>
+                        <div className="settings-share-action-text">
+                          <span className="settings-share-action-title">Remove from series</span>
+                          <span className="settings-share-action-desc">Detach this board from its series</span>
                         </div>
                         <ChevronRight size={16} className="settings-share-action-chevron" aria-hidden="true" />
                       </button>

--- a/src/components/modals/LinkPreviousBoardModal.jsx
+++ b/src/components/modals/LinkPreviousBoardModal.jsx
@@ -61,7 +61,7 @@ const LinkPreviousBoardModal = ({ isOpen, onClose, currentBoardId, onLink }) => 
         showNotification('Linked to previous board');
         onClose();
       } else {
-        showNotification("Couldn't find that board");
+        showNotification("Couldn't link that board — it may not exist, or linking it would create a loop in the series");
       }
     } catch {
       showNotification('Something went wrong linking the board');

--- a/src/components/modals/LinkPreviousBoardModal.jsx
+++ b/src/components/modals/LinkPreviousBoardModal.jsx
@@ -1,0 +1,144 @@
+import { useMemo, useRef, useState } from 'react';
+import { Link2 } from 'react-feather';
+import { useNotification } from '../../context/NotificationContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { useRecentBoards } from '../../hooks/useRecentBoards';
+import { extractBoardId } from '../../utils/boardLink';
+
+/**
+ * Modal for linking the current board to a previously-created board as the
+ * previous entry in a series. Lets the user paste a board link/ID or pick from
+ * their recent boards.
+ *
+ * @param {Object} props
+ * @param {boolean} props.isOpen - Whether the modal is open
+ * @param {Function} props.onClose - Close handler
+ * @param {string} props.currentBoardId - The current board's ID (excluded from picker)
+ * @param {Function} props.onLink - async (previousBoardId) => boolean; resolves true on success
+ */
+const LinkPreviousBoardModal = ({ isOpen, onClose, currentBoardId, onLink }) => {
+  const { recentBoards } = useRecentBoards();
+  const { showNotification } = useNotification();
+  const modalRef = useRef(null);
+  const [inputValue, setInputValue] = useState('');
+  const [selectedId, setSelectedId] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useFocusTrap(modalRef, isOpen, { onClose });
+
+  const candidates = useMemo(
+    () => (recentBoards || []).filter(b => b.id !== currentBoardId),
+    [recentBoards, currentBoardId]
+  );
+
+  if (!isOpen) return null;
+
+  const handleSelectRecent = (id) => {
+    setSelectedId(id);
+    setInputValue('');
+  };
+
+  const handleInputChange = (e) => {
+    setInputValue(e.target.value);
+    setSelectedId(null);
+  };
+
+  const handleLink = async () => {
+    const targetId = extractBoardId(inputValue) || selectedId;
+    if (!targetId) {
+      showNotification('Enter a board link or pick a recent board');
+      return;
+    }
+    if (targetId === currentBoardId) {
+      showNotification("A board can't be linked to itself");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const ok = await onLink(targetId);
+      if (ok) {
+        showNotification('Linked to previous board');
+        onClose();
+      } else {
+        showNotification("Couldn't find that board");
+      }
+    } catch {
+      showNotification('Something went wrong linking the board');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose} role="presentation">
+      <div
+        className="modal-container link-previous-modal"
+        ref={modalRef}
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="link-previous-title"
+      >
+        <div className="modal-header">
+          <h2 id="link-previous-title">Link to previous board</h2>
+          <button className="close-button" onClick={onClose} aria-label="Close">
+            &times;
+          </button>
+        </div>
+
+        <div className="modal-body">
+          <p className="link-previous-help">
+            Connect this board to an earlier one so you can page back to it — handy for
+            reviewing the previous board&apos;s commitments.
+          </p>
+
+          <label className="link-previous-label" htmlFor="link-previous-input">
+            Paste a board link or ID
+          </label>
+          <input
+            id="link-previous-input"
+            type="text"
+            className="link-previous-input"
+            placeholder="https://www.kanbanish.com/?board=…"
+            value={inputValue}
+            onChange={handleInputChange}
+          />
+
+          {candidates.length > 0 && (
+            <>
+              <div className="link-previous-divider">or pick a recent board</div>
+              <div className="link-previous-list">
+                {candidates.map(board => (
+                  <button
+                    key={board.id}
+                    type="button"
+                    className={`link-previous-item ${selectedId === board.id ? 'selected' : ''}`}
+                    onClick={() => handleSelectRecent(board.id)}
+                    aria-pressed={selectedId === board.id}
+                  >
+                    <span className="link-previous-item-title">
+                      {board.title || 'Untitled Board'}
+                    </span>
+                    <span className="link-previous-item-meta">{board.cardCount || 0} cards</span>
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="modal-footer">
+          <button className="btn secondary-btn" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button className="btn primary-btn" onClick={handleLink} disabled={submitting}>
+            <Link2 size={16} aria-hidden="true" /> Link board
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LinkPreviousBoardModal;

--- a/src/context/BoardContext.jsx
+++ b/src/context/BoardContext.jsx
@@ -2,6 +2,7 @@ import { ref, onValue, off, set } from 'firebase/database';
 import { createContext, useCallback, useContext, useRef, useState, useEffect, useMemo } from 'react';
 import { useActionItems } from '../hooks/useActionItems';
 import { useBoardBackground } from '../hooks/useBoardBackground';
+import { useBoardSeries } from '../hooks/useBoardSeries';
 import { useBoardSettings } from '../hooks/useBoardSettings';
 import { useColumnTimer } from '../hooks/useColumnTimer';
 import { useGroups } from '../hooks/useGroups';
@@ -76,6 +77,11 @@ export const BoardProvider = ({ children, initialBoardId = null }) => {
   // Action items state
   const [actionItems, setActionItems] = useState({});
   const [actionItemsEnabled, setActionItemsEnabled] = useState(false); // Default to disabled
+
+  // Board series: pointers linking this board to its neighbours in a chain
+  const [previousBoardId, setPreviousBoardId] = useState(null);
+  const [nextBoardId, setNextBoardId] = useState(null);
+
   const initialWorkflowPhaseRef = useRef(null); // Captures the workflowPhase on first board load
   const [initialWorkflowPhase, setInitialWorkflowPhase] = useState(null);
 
@@ -248,6 +254,10 @@ export const BoardProvider = ({ children, initialBoardId = null }) => {
 
           // Load action items
           setActionItems(boardData.actionItems || {});
+
+          // Load board series pointers
+          setPreviousBoardId(boardData.previousBoardId || null);
+          setNextBoardId(boardData.nextBoardId || null);
         }
       });
 
@@ -419,6 +429,11 @@ export const BoardProvider = ({ children, initialBoardId = null }) => {
     createActionItem, updateActionItemStatus, updateActionItemAssignee,
     updateActionItemDueDate, updateActionItemDescription, deleteActionItem
   } = useActionItems({ boardId, user, columns });
+
+  // Board series operations (link boards into an ordered chain)
+  const {
+    startNextBoard, linkToPreviousBoard, unlinkFromSeries
+  } = useBoardSeries({ boardId, user });
 
   // Compute board-wide tags
   const boardTags = useMemo(() => {
@@ -644,6 +659,8 @@ export const BoardProvider = ({ children, initialBoardId = null }) => {
       actionItems, actionItemsEnabled, updateActionItemsEnabled,
       createActionItem, updateActionItemStatus, updateActionItemAssignee,
       updateActionItemDueDate, updateActionItemDescription, deleteActionItem,
+      // Board series
+      previousBoardId, nextBoardId, startNextBoard, linkToPreviousBoard, unlinkFromSeries,
       // Board background
       backgroundId, customBackgroundCss, customBackgroundSize: customBackgroundSizeState,
       setBoardBackground, setCustomBackground, setCustomBackgroundSize, clearBackground
@@ -680,6 +697,7 @@ export const BoardProvider = ({ children, initialBoardId = null }) => {
     actionItems, actionItemsEnabled, updateActionItemsEnabled, createActionItem,
     updateActionItemStatus, updateActionItemAssignee, updateActionItemDueDate,
     updateActionItemDescription, deleteActionItem,
+    previousBoardId, nextBoardId, startNextBoard, linkToPreviousBoard, unlinkFromSeries,
     backgroundId, customBackgroundCss, customBackgroundSizeState, setBoardBackground, setCustomBackground, setCustomBackgroundSize, clearBackground
   ]);
   return <BoardContext.Provider value={value}>{children}</BoardContext.Provider>;

--- a/src/hooks/useBoardSeries.js
+++ b/src/hooks/useBoardSeries.js
@@ -8,6 +8,10 @@ import { WORKFLOW_PHASES } from '../utils/workflowUtils';
 const DEFAULT_BOARD_TITLE = 'Untitled Board';
 const ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
 
+// Safety bound when walking a series chain (e.g. for cycle detection), so a
+// corrupt chain in the database can never make us loop forever.
+const MAX_CHAIN_WALK = 500;
+
 /**
  * Build a fresh columns object from an existing board's columns, preserving
  * order and titles but starting with no cards. Used to clone the "shape" of a
@@ -83,6 +87,16 @@ export const useBoardSeries = ({ boardId, user }) => {
       operationName: 'Create next board in series'
     });
 
+    // If the current board already had a successor, detach its back-pointer so
+    // it doesn't keep claiming this board as its predecessor.
+    const oldNextId = currentData.nextBoardId;
+    if (oldNextId) {
+      await withRetry(
+        () => remove(ref(database, `boards/${oldNextId}/previousBoardId`)),
+        { operationName: 'Detach replaced next board' }
+      );
+    }
+
     // Link the current board forward to the new one.
     await withRetry(
       () => set(ref(database, `boards/${boardId}/nextBoardId`), newBoardId),
@@ -96,8 +110,12 @@ export const useBoardSeries = ({ boardId, user }) => {
    * Link the current board to a previously-created board as its predecessor.
    * Sets a doubly-linked pointer pair so the pager can page in both directions.
    *
+   * Refuses links that would create a cycle (the current board already appears
+   * earlier in the target's chain), and detaches any pointers the new link
+   * replaces so no dangling back-references are left behind.
+   *
    * @param {string} previousBoardId - The board ID to link as the previous board
-   * @returns {Promise<boolean>} True when linked, false on invalid input/missing board
+   * @returns {Promise<boolean>} True when linked, false on invalid input/missing board/cycle
    */
   const linkToPreviousBoard = useCallback(
     async (previousBoardId) => {
@@ -108,6 +126,41 @@ export const useBoardSeries = ({ boardId, user }) => {
       // Make sure the target board actually exists before linking.
       const targetSnapshot = await get(ref(database, `boards/${trimmed}`));
       if (!targetSnapshot.exists()) return false;
+      const targetData = targetSnapshot.val() || {};
+
+      // Cycle guard: walk the target's predecessor chain — if the current
+      // board is already an ancestor, this link would make the series loop.
+      let ancestorId = targetData.previousBoardId;
+      for (let hops = 0; ancestorId && hops < MAX_CHAIN_WALK; hops++) {
+        if (ancestorId === boardId) return false;
+        const ancestorSnapshot = await get(
+          ref(database, `boards/${ancestorId}/previousBoardId`)
+        );
+        ancestorId = ancestorSnapshot.val();
+      }
+
+      // If this board already had a different predecessor, detach that board's
+      // forward pointer so it no longer claims this board as its successor.
+      const oldPreviousSnapshot = await get(
+        ref(database, `boards/${boardId}/previousBoardId`)
+      );
+      const oldPreviousId = oldPreviousSnapshot.val();
+      if (oldPreviousId && oldPreviousId !== trimmed) {
+        await withRetry(
+          () => remove(ref(database, `boards/${oldPreviousId}/nextBoardId`)),
+          { operationName: 'Detach replaced previous board' }
+        );
+      }
+
+      // If the target already had a different successor, detach its
+      // back-pointer for the same reason.
+      const oldTargetNextId = targetData.nextBoardId;
+      if (oldTargetNextId && oldTargetNextId !== boardId) {
+        await withRetry(
+          () => remove(ref(database, `boards/${oldTargetNextId}/previousBoardId`)),
+          { operationName: "Detach target's replaced next board" }
+        );
+      }
 
       await withRetry(
         () => set(ref(database, `boards/${boardId}/previousBoardId`), trimmed),
@@ -124,8 +177,10 @@ export const useBoardSeries = ({ boardId, user }) => {
   );
 
   /**
-   * Detach the current board from its series, removing its own pointers and the
-   * reciprocal pointers on its immediate neighbours.
+   * Detach the current board from its series, removing its own pointers. When
+   * the board sits in the middle of a chain, its two neighbours are spliced
+   * together so the rest of the series stays intact; at either end, the lone
+   * neighbour's reciprocal pointer is simply removed.
    *
    * @returns {Promise<void>}
    */
@@ -136,13 +191,22 @@ export const useBoardSeries = ({ boardId, user }) => {
     const currentData = currentSnapshot.val() || {};
     const { previousBoardId, nextBoardId } = currentData;
 
-    if (previousBoardId) {
+    if (previousBoardId && nextBoardId) {
+      // Middle of the chain: splice the neighbours together.
+      await withRetry(
+        () => set(ref(database, `boards/${previousBoardId}/nextBoardId`), nextBoardId),
+        { operationName: 'Splice previous neighbour forward' }
+      );
+      await withRetry(
+        () => set(ref(database, `boards/${nextBoardId}/previousBoardId`), previousBoardId),
+        { operationName: 'Splice next neighbour backward' }
+      );
+    } else if (previousBoardId) {
       await withRetry(
         () => remove(ref(database, `boards/${previousBoardId}/nextBoardId`)),
         { operationName: 'Unlink previous neighbour' }
       );
-    }
-    if (nextBoardId) {
+    } else if (nextBoardId) {
       await withRetry(
         () => remove(ref(database, `boards/${nextBoardId}/previousBoardId`)),
         { operationName: 'Unlink next neighbour' }

--- a/src/hooks/useBoardSeries.js
+++ b/src/hooks/useBoardSeries.js
@@ -1,0 +1,165 @@
+import { ref, get, set, remove } from 'firebase/database';
+import { useCallback } from 'react';
+import { database } from '../utils/firebase';
+import { withRetry } from '../utils/firebaseRetry';
+import { generateId } from '../utils/ids';
+import { WORKFLOW_PHASES } from '../utils/workflowUtils';
+
+const DEFAULT_BOARD_TITLE = 'Untitled Board';
+const ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
+
+/**
+ * Build a fresh columns object from an existing board's columns, preserving
+ * order and titles but starting with no cards. Used to clone the "shape" of a
+ * board when starting the next board in a series.
+ *
+ * @param {Object} sourceColumns - The source board's columns map
+ * @returns {Object} A new columns map (empty cards, re-prefixed keys)
+ */
+function cloneColumnStructure(sourceColumns) {
+  const columnsObj = {};
+  const ordered = Object.entries(sourceColumns || {}).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+
+  ordered.forEach(([, column], index) => {
+    const prefix = index < 26 ? ALPHABET[index] : `col${index}`;
+    const newColumn = { title: column?.title || '', cards: {} };
+    if (column?.defaultTimerSeconds) {
+      newColumn.defaultTimerSeconds = column.defaultTimerSeconds;
+    }
+    columnsObj[`${prefix}_${generateId()}`] = newColumn;
+  });
+
+  return columnsObj;
+}
+
+/**
+ * Hook for board series operations — linking boards into an ordered chain so
+ * users can page back to previous boards (e.g. to review a prior retro's
+ * commitments). Pointers are stored on the board nodes in Firebase so the
+ * relationship is shared with everyone, not local to one browser.
+ *
+ *   boards/{boardId}/previousBoardId
+ *   boards/{boardId}/nextBoardId
+ *
+ * @param {Object} params
+ * @param {string|null} params.boardId - Current board ID
+ * @param {Object|null} params.user - Current Firebase user
+ * @returns {Object} Series operations
+ */
+export const useBoardSeries = ({ boardId, user }) => {
+  /**
+   * Create the next board in the series: clones the current board's column
+   * structure and settings (with empty cards), links the two boards together,
+   * and returns the new board ID so the caller can navigate to it.
+   *
+   * @returns {Promise<string|null>} The new board ID, or null if unavailable
+   */
+  const startNextBoard = useCallback(async () => {
+    if (!boardId || !user) return null;
+
+    const currentSnapshot = await get(ref(database, `boards/${boardId}`));
+    const currentData = currentSnapshot.val() || {};
+
+    const newBoardId = generateId();
+
+    // Clone settings verbatim to keep the same "shape", but reset the
+    // transient workflow position so the new board starts fresh.
+    const settings = { ...(currentData.settings || {}) };
+    settings.workflowPhase = WORKFLOW_PHASES.CREATION;
+    settings.resultsViewIndex = 0;
+
+    const initialData = {
+      title: currentData.title || DEFAULT_BOARD_TITLE,
+      created: Date.now(),
+      owner: user.uid,
+      columns: cloneColumnStructure(currentData.columns),
+      settings,
+      previousBoardId: boardId
+    };
+
+    await withRetry(() => set(ref(database, `boards/${newBoardId}`), initialData), {
+      operationName: 'Create next board in series'
+    });
+
+    // Link the current board forward to the new one.
+    await withRetry(
+      () => set(ref(database, `boards/${boardId}/nextBoardId`), newBoardId),
+      { operationName: 'Link board to next' }
+    );
+
+    return newBoardId;
+  }, [boardId, user]);
+
+  /**
+   * Link the current board to a previously-created board as its predecessor.
+   * Sets a doubly-linked pointer pair so the pager can page in both directions.
+   *
+   * @param {string} previousBoardId - The board ID to link as the previous board
+   * @returns {Promise<boolean>} True when linked, false on invalid input/missing board
+   */
+  const linkToPreviousBoard = useCallback(
+    async (previousBoardId) => {
+      if (!boardId || !user) return false;
+      const trimmed = (previousBoardId || '').trim();
+      if (!trimmed || trimmed === boardId) return false;
+
+      // Make sure the target board actually exists before linking.
+      const targetSnapshot = await get(ref(database, `boards/${trimmed}`));
+      if (!targetSnapshot.exists()) return false;
+
+      await withRetry(
+        () => set(ref(database, `boards/${boardId}/previousBoardId`), trimmed),
+        { operationName: 'Link board to previous' }
+      );
+      await withRetry(
+        () => set(ref(database, `boards/${trimmed}/nextBoardId`), boardId),
+        { operationName: 'Link previous board forward' }
+      );
+
+      return true;
+    },
+    [boardId, user]
+  );
+
+  /**
+   * Detach the current board from its series, removing its own pointers and the
+   * reciprocal pointers on its immediate neighbours.
+   *
+   * @returns {Promise<void>}
+   */
+  const unlinkFromSeries = useCallback(async () => {
+    if (!boardId || !user) return;
+
+    const currentSnapshot = await get(ref(database, `boards/${boardId}`));
+    const currentData = currentSnapshot.val() || {};
+    const { previousBoardId, nextBoardId } = currentData;
+
+    if (previousBoardId) {
+      await withRetry(
+        () => remove(ref(database, `boards/${previousBoardId}/nextBoardId`)),
+        { operationName: 'Unlink previous neighbour' }
+      );
+    }
+    if (nextBoardId) {
+      await withRetry(
+        () => remove(ref(database, `boards/${nextBoardId}/previousBoardId`)),
+        { operationName: 'Unlink next neighbour' }
+      );
+    }
+
+    await withRetry(() => remove(ref(database, `boards/${boardId}/previousBoardId`)), {
+      operationName: 'Remove own previous pointer'
+    });
+    await withRetry(() => remove(ref(database, `boards/${boardId}/nextBoardId`)), {
+      operationName: 'Remove own next pointer'
+    });
+  }, [boardId, user]);
+
+  return {
+    startNextBoard,
+    linkToPreviousBoard,
+    unlinkFromSeries
+  };
+};

--- a/src/hooks/useBoardSeries.test.js
+++ b/src/hooks/useBoardSeries.test.js
@@ -29,6 +29,13 @@ const snapshot = (value) => ({
   exists: () => value !== null && value !== undefined
 });
 
+// Mock get() with a map of path → value, since the ref mock returns the path.
+const mockGetByPath = (map) => {
+  get.mockImplementation((path) => Promise.resolve(snapshot(
+    Object.prototype.hasOwnProperty.call(map, path) ? map[path] : null
+  )));
+};
+
 const createProps = (overrides = {}) => ({
   boardId: 'board-current',
   user: { uid: 'user-1' },
@@ -109,6 +116,26 @@ describe('useBoardSeries', () => {
       const [currentNextPath, nextValue] = set.mock.calls[1];
       expect(currentNextPath).toBe('boards/board-current/nextBoardId');
       expect(nextValue).toBe(newId);
+
+      // The replaced successor's back-pointer is detached so it no longer
+      // claims the current board as its predecessor.
+      expect(remove).toHaveBeenCalledWith('boards/should-be-overwritten/previousBoardId');
+    });
+
+    it('does not detach anything when the current board has no successor', async () => {
+      get.mockResolvedValueOnce(
+        snapshot({
+          title: 'Standalone',
+          columns: { a_one: { title: 'Start', cards: {} } }
+        })
+      );
+
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      await act(async () => {
+        await result.current.startNextBoard();
+      });
+
+      expect(remove).not.toHaveBeenCalled();
     });
   });
 
@@ -145,7 +172,7 @@ describe('useBoardSeries', () => {
     });
 
     it('sets both reciprocal pointers when the target exists', async () => {
-      get.mockResolvedValueOnce(snapshot({ title: 'Older board' }));
+      mockGetByPath({ 'boards/board-older': { title: 'Older board' } });
       const { result } = renderHook(() => useBoardSeries(createProps()));
       let ok;
       await act(async () => {
@@ -154,32 +181,129 @@ describe('useBoardSeries', () => {
       expect(ok).toBe(true);
       expect(set).toHaveBeenCalledWith('boards/board-current/previousBoardId', 'board-older');
       expect(set).toHaveBeenCalledWith('boards/board-older/nextBoardId', 'board-current');
+      expect(remove).not.toHaveBeenCalled();
+    });
+
+    it("detaches the current board's replaced predecessor", async () => {
+      mockGetByPath({
+        'boards/board-older': { title: 'Older board' },
+        'boards/board-current/previousBoardId': 'board-old-prev'
+      });
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      let ok;
+      await act(async () => {
+        ok = await result.current.linkToPreviousBoard('board-older');
+      });
+      expect(ok).toBe(true);
+      expect(remove).toHaveBeenCalledWith('boards/board-old-prev/nextBoardId');
+      expect(set).toHaveBeenCalledWith('boards/board-current/previousBoardId', 'board-older');
+    });
+
+    it("detaches the target's replaced successor", async () => {
+      mockGetByPath({
+        'boards/board-older': { title: 'Older board', nextBoardId: 'board-target-next' }
+      });
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      let ok;
+      await act(async () => {
+        ok = await result.current.linkToPreviousBoard('board-older');
+      });
+      expect(ok).toBe(true);
+      expect(remove).toHaveBeenCalledWith('boards/board-target-next/previousBoardId');
+      expect(set).toHaveBeenCalledWith('boards/board-older/nextBoardId', 'board-current');
+    });
+
+    it('re-linking the same pair detaches nothing', async () => {
+      mockGetByPath({
+        'boards/board-older': { title: 'Older board', nextBoardId: 'board-current' },
+        'boards/board-current/previousBoardId': 'board-older'
+      });
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      let ok;
+      await act(async () => {
+        ok = await result.current.linkToPreviousBoard('board-older');
+      });
+      expect(ok).toBe(true);
+      expect(remove).not.toHaveBeenCalled();
+    });
+
+    it('refuses a link that would create a direct cycle', async () => {
+      // board-b already lists the current board as its predecessor.
+      mockGetByPath({
+        'boards/board-b': { title: 'B', previousBoardId: 'board-current' }
+      });
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      let ok;
+      await act(async () => {
+        ok = await result.current.linkToPreviousBoard('board-b');
+      });
+      expect(ok).toBe(false);
+      expect(set).not.toHaveBeenCalled();
+      expect(remove).not.toHaveBeenCalled();
+    });
+
+    it('refuses a link that would create a deeper cycle', async () => {
+      // Chain: board-current → … → board-b → board-c; linking board-c as
+      // current's predecessor would loop.
+      mockGetByPath({
+        'boards/board-c': { title: 'C', previousBoardId: 'board-b' },
+        'boards/board-b/previousBoardId': 'board-current'
+      });
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      let ok;
+      await act(async () => {
+        ok = await result.current.linkToPreviousBoard('board-c');
+      });
+      expect(ok).toBe(false);
+      expect(set).not.toHaveBeenCalled();
+      expect(remove).not.toHaveBeenCalled();
     });
   });
 
   describe('unlinkFromSeries', () => {
-    it('removes reciprocal neighbour pointers and own pointers', async () => {
-      get.mockResolvedValueOnce(
-        snapshot({ previousBoardId: 'board-prev', nextBoardId: 'board-next' })
-      );
+    it('splices the neighbours together when unlinking a middle board', async () => {
+      mockGetByPath({
+        'boards/board-current': { previousBoardId: 'board-prev', nextBoardId: 'board-next' }
+      });
       const { result } = renderHook(() => useBoardSeries(createProps()));
       await act(async () => {
         await result.current.unlinkFromSeries();
       });
-      expect(remove).toHaveBeenCalledWith('boards/board-prev/nextBoardId');
-      expect(remove).toHaveBeenCalledWith('boards/board-next/previousBoardId');
+      // Neighbours now point at each other, keeping the rest of the series intact.
+      expect(set).toHaveBeenCalledWith('boards/board-prev/nextBoardId', 'board-next');
+      expect(set).toHaveBeenCalledWith('boards/board-next/previousBoardId', 'board-prev');
+      // Own pointers are removed.
       expect(remove).toHaveBeenCalledWith('boards/board-current/previousBoardId');
       expect(remove).toHaveBeenCalledWith('boards/board-current/nextBoardId');
+      // Neighbour pointers are spliced, not removed.
+      expect(remove).not.toHaveBeenCalledWith('boards/board-prev/nextBoardId');
+      expect(remove).not.toHaveBeenCalledWith('boards/board-next/previousBoardId');
     });
 
-    it('only removes existing links', async () => {
-      get.mockResolvedValueOnce(snapshot({ previousBoardId: 'board-prev' }));
+    it('removes the lone neighbour pointer when unlinking the last board', async () => {
+      mockGetByPath({
+        'boards/board-current': { previousBoardId: 'board-prev' }
+      });
       const { result } = renderHook(() => useBoardSeries(createProps()));
       await act(async () => {
         await result.current.unlinkFromSeries();
       });
       expect(remove).toHaveBeenCalledWith('boards/board-prev/nextBoardId');
-      expect(remove).not.toHaveBeenCalledWith('boards/undefined/previousBoardId');
+      expect(remove).toHaveBeenCalledWith('boards/board-current/previousBoardId');
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it('removes the lone neighbour pointer when unlinking the first board', async () => {
+      mockGetByPath({
+        'boards/board-current': { nextBoardId: 'board-next' }
+      });
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      await act(async () => {
+        await result.current.unlinkFromSeries();
+      });
+      expect(remove).toHaveBeenCalledWith('boards/board-next/previousBoardId');
+      expect(remove).toHaveBeenCalledWith('boards/board-current/nextBoardId');
+      expect(set).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/useBoardSeries.test.js
+++ b/src/hooks/useBoardSeries.test.js
@@ -1,0 +1,185 @@
+import { renderHook, act } from '@testing-library/react';
+import { get, set, remove } from 'firebase/database';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useBoardSeries } from './useBoardSeries';
+
+vi.mock('../utils/firebase', () => ({
+  database: {}
+}));
+
+vi.mock('firebase/database', () => ({
+  ref: vi.fn((_db, path) => path),
+  get: vi.fn(),
+  set: vi.fn(() => Promise.resolve()),
+  remove: vi.fn(() => Promise.resolve())
+}));
+
+// Pass-through retry so we can assert on the underlying set/remove calls.
+vi.mock('../utils/firebaseRetry', () => ({
+  withRetry: vi.fn((operation) => operation())
+}));
+
+let idCounter = 0;
+vi.mock('../utils/ids', () => ({
+  generateId: vi.fn(() => `gen-${++idCounter}`)
+}));
+
+const snapshot = (value) => ({
+  val: () => value,
+  exists: () => value !== null && value !== undefined
+});
+
+const createProps = (overrides = {}) => ({
+  boardId: 'board-current',
+  user: { uid: 'user-1' },
+  ...overrides
+});
+
+describe('useBoardSeries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    idCounter = 0;
+  });
+
+  describe('startNextBoard', () => {
+    it('returns null and writes nothing when boardId is missing', async () => {
+      const { result } = renderHook(() => useBoardSeries(createProps({ boardId: null })));
+      let returned;
+      await act(async () => {
+        returned = await result.current.startNextBoard();
+      });
+      expect(returned).toBeNull();
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it('returns null and writes nothing when user is missing', async () => {
+      const { result } = renderHook(() => useBoardSeries(createProps({ user: null })));
+      let returned;
+      await act(async () => {
+        returned = await result.current.startNextBoard();
+      });
+      expect(returned).toBeNull();
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it('clones columns + settings, links pointers, and returns the new board id', async () => {
+      get.mockResolvedValueOnce(
+        snapshot({
+          title: 'Sprint Retro',
+          settings: {
+            retrospectiveMode: true,
+            votingEnabled: true,
+            workflowPhase: 'RESULTS',
+            resultsViewIndex: 3
+          },
+          columns: {
+            b_two: { title: 'Stop', cards: { c1: {} }, defaultTimerSeconds: 60 },
+            a_one: { title: 'Start', cards: { c2: {} } }
+          },
+          nextBoardId: 'should-be-overwritten'
+        })
+      );
+
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      let newId;
+      await act(async () => {
+        newId = await result.current.startNextBoard();
+      });
+
+      // First set() creates the new board.
+      const [newBoardPath, newBoardData] = set.mock.calls[0];
+      expect(newBoardPath).toBe(`boards/${newId}`);
+      expect(newBoardData.title).toBe('Sprint Retro');
+      expect(newBoardData.owner).toBe('user-1');
+      expect(newBoardData.previousBoardId).toBe('board-current');
+      // Settings cloned but workflow position reset.
+      expect(newBoardData.settings.retrospectiveMode).toBe(true);
+      expect(newBoardData.settings.workflowPhase).toBe('CREATION');
+      expect(newBoardData.settings.resultsViewIndex).toBe(0);
+
+      // Columns cloned: order preserved (a_ before b_), empty cards, no stray next pointer.
+      const columnTitles = Object.values(newBoardData.columns).map(c => c.title);
+      expect(columnTitles).toEqual(['Start', 'Stop']);
+      Object.values(newBoardData.columns).forEach(c => {
+        expect(c.cards).toEqual({});
+      });
+      expect(newBoardData.nextBoardId).toBeUndefined();
+
+      // Second set() links the current board forward to the new one.
+      const [currentNextPath, nextValue] = set.mock.calls[1];
+      expect(currentNextPath).toBe('boards/board-current/nextBoardId');
+      expect(nextValue).toBe(newId);
+    });
+  });
+
+  describe('linkToPreviousBoard', () => {
+    it('returns false for empty input', async () => {
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      let ok;
+      await act(async () => {
+        ok = await result.current.linkToPreviousBoard('   ');
+      });
+      expect(ok).toBe(false);
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it('returns false when trying to link a board to itself', async () => {
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      let ok;
+      await act(async () => {
+        ok = await result.current.linkToPreviousBoard('board-current');
+      });
+      expect(ok).toBe(false);
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the target board does not exist', async () => {
+      get.mockResolvedValueOnce(snapshot(null));
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      let ok;
+      await act(async () => {
+        ok = await result.current.linkToPreviousBoard('board-missing');
+      });
+      expect(ok).toBe(false);
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it('sets both reciprocal pointers when the target exists', async () => {
+      get.mockResolvedValueOnce(snapshot({ title: 'Older board' }));
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      let ok;
+      await act(async () => {
+        ok = await result.current.linkToPreviousBoard('board-older');
+      });
+      expect(ok).toBe(true);
+      expect(set).toHaveBeenCalledWith('boards/board-current/previousBoardId', 'board-older');
+      expect(set).toHaveBeenCalledWith('boards/board-older/nextBoardId', 'board-current');
+    });
+  });
+
+  describe('unlinkFromSeries', () => {
+    it('removes reciprocal neighbour pointers and own pointers', async () => {
+      get.mockResolvedValueOnce(
+        snapshot({ previousBoardId: 'board-prev', nextBoardId: 'board-next' })
+      );
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      await act(async () => {
+        await result.current.unlinkFromSeries();
+      });
+      expect(remove).toHaveBeenCalledWith('boards/board-prev/nextBoardId');
+      expect(remove).toHaveBeenCalledWith('boards/board-next/previousBoardId');
+      expect(remove).toHaveBeenCalledWith('boards/board-current/previousBoardId');
+      expect(remove).toHaveBeenCalledWith('boards/board-current/nextBoardId');
+    });
+
+    it('only removes existing links', async () => {
+      get.mockResolvedValueOnce(snapshot({ previousBoardId: 'board-prev' }));
+      const { result } = renderHook(() => useBoardSeries(createProps()));
+      await act(async () => {
+        await result.current.unlinkFromSeries();
+      });
+      expect(remove).toHaveBeenCalledWith('boards/board-prev/nextBoardId');
+      expect(remove).not.toHaveBeenCalledWith('boards/undefined/previousBoardId');
+    });
+  });
+});

--- a/src/styles/components/board-series.css
+++ b/src/styles/components/board-series.css
@@ -1,0 +1,140 @@
+/*
+ * Board Series Styles
+ * Pager controls in the header + the "link to previous board" modal.
+ */
+
+/* --- Header pager --- */
+.board-series-pager {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+}
+
+.board-series-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  height: 32px;
+  padding: 0 var(--space-sm);
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+  white-space: nowrap;
+  transition: all var(--transition-speed) var(--transition-ease);
+}
+
+.board-series-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.board-series-btn-label {
+  line-height: 1;
+}
+
+/* Collapse the text labels on narrow screens — keep the chevrons */
+@media (max-width: 640px) {
+  .board-series-btn-label {
+    display: none;
+  }
+
+  .board-series-btn {
+    padding: 0 var(--space-xs);
+  }
+}
+
+/* --- Link to previous board modal --- */
+.link-previous-modal {
+  max-width: 480px;
+  width: 100%;
+}
+
+.link-previous-help {
+  margin: 0 0 var(--space-md);
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.link-previous-label {
+  display: block;
+  margin-bottom: var(--space-xs);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.link-previous-input {
+  width: 100%;
+  padding: var(--space-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-color);
+  font-size: 0.875rem;
+}
+
+.link-previous-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.link-previous-divider {
+  margin: var(--space-md) 0 var(--space-sm);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.link-previous-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.link-previous-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  width: 100%;
+  padding: var(--space-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-color);
+  cursor: pointer;
+  text-align: left;
+  transition: all var(--transition-speed) var(--transition-ease);
+}
+
+.link-previous-item:hover {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.link-previous-item.selected {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.link-previous-item-title {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.link-previous-item-meta {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -36,6 +36,7 @@
 @import 'components/board-background.css';
 @import 'components/focus-mode.css';
 @import 'components/card-detail-modal.css';
+@import 'components/board-series.css';
 
 /* Utility classes and notifications */
 .notification {

--- a/src/utils/boardLink.js
+++ b/src/utils/boardLink.js
@@ -3,6 +3,7 @@
  *
  * Accepts:
  *   - A full URL containing a `?board=<id>` query param
+ *   - A protocol-less URL like `www.kanbanish.com/?board=<id>`
  *   - A bare board ID (no whitespace, not a URL)
  *
  * @param {string} input - The pasted URL or ID
@@ -13,13 +14,22 @@ export function extractBoardId(input) {
   const trimmed = input.trim();
   if (!trimmed) return null;
 
-  // Try to parse as a URL and read the ?board= param.
-  try {
-    const url = new URL(trimmed);
-    const boardParam = url.searchParams.get('board');
-    if (boardParam) return boardParam.trim();
-  } catch {
-    // Not a URL — fall through to bare-ID handling.
+  const boardIdFromUrl = (candidate) => {
+    try {
+      const boardParam = new URL(candidate).searchParams.get('board');
+      return boardParam ? boardParam.trim() : null;
+    } catch {
+      return null;
+    }
+  };
+
+  // Try to parse as a URL and read the ?board= param — first as-is, then with
+  // an assumed https:// prefix for protocol-less pastes.
+  const direct = boardIdFromUrl(trimmed);
+  if (direct) return direct;
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    const prefixed = boardIdFromUrl(`https://${trimmed}`);
+    if (prefixed) return prefixed;
   }
 
   // A bare ID can't contain whitespace, slashes, or query characters.

--- a/src/utils/boardLink.js
+++ b/src/utils/boardLink.js
@@ -1,0 +1,29 @@
+/**
+ * Extracts a board ID from user input that may be a full board URL or a bare ID.
+ *
+ * Accepts:
+ *   - A full URL containing a `?board=<id>` query param
+ *   - A bare board ID (no whitespace, not a URL)
+ *
+ * @param {string} input - The pasted URL or ID
+ * @returns {string|null} The extracted board ID, or null if none could be found
+ */
+export function extractBoardId(input) {
+  if (!input || typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // Try to parse as a URL and read the ?board= param.
+  try {
+    const url = new URL(trimmed);
+    const boardParam = url.searchParams.get('board');
+    if (boardParam) return boardParam.trim();
+  } catch {
+    // Not a URL — fall through to bare-ID handling.
+  }
+
+  // A bare ID can't contain whitespace, slashes, or query characters.
+  if (/[\s/?#]/.test(trimmed)) return null;
+
+  return trimmed;
+}

--- a/src/utils/boardLink.test.js
+++ b/src/utils/boardLink.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { extractBoardId } from './boardLink';
+
+describe('extractBoardId', () => {
+  it('extracts the id from a full board URL', () => {
+    expect(extractBoardId('https://www.kanbanish.com/?board=abc123')).toBe('abc123');
+  });
+
+  it('extracts the id when other query params are present', () => {
+    expect(extractBoardId('https://www.kanbanish.com/?theme=dark&board=abc123')).toBe('abc123');
+  });
+
+  it('extracts the id from a protocol-less URL', () => {
+    expect(extractBoardId('www.kanbanish.com/?board=abc123')).toBe('abc123');
+  });
+
+  it('extracts the id from a localhost URL with a port', () => {
+    expect(extractBoardId('http://localhost:3000/?board=abc123')).toBe('abc123');
+  });
+
+  it('accepts a bare board id', () => {
+    expect(extractBoardId('abc123')).toBe('abc123');
+  });
+
+  it('trims surrounding whitespace from a bare id', () => {
+    expect(extractBoardId('  abc123  ')).toBe('abc123');
+  });
+
+  it('returns null for a URL without a board param', () => {
+    expect(extractBoardId('https://www.kanbanish.com/')).toBeNull();
+  });
+
+  it('returns null for input with internal whitespace', () => {
+    expect(extractBoardId('abc 123')).toBeNull();
+  });
+
+  it('returns null for path-like input without a board param', () => {
+    expect(extractBoardId('kanbanish.com/some/path')).toBeNull();
+  });
+
+  it('returns null for empty or non-string input', () => {
+    expect(extractBoardId('')).toBeNull();
+    expect(extractBoardId('   ')).toBeNull();
+    expect(extractBoardId(null)).toBeNull();
+    expect(extractBoardId(undefined)).toBeNull();
+    expect(extractBoardId(42)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why

Lets a board be marked as the **next in a series** of a previous board, so you can **page back/forward** between linked boards — e.g. to review the previous retro's commitments. Works in **both kanban and retrospective** formats (it links *boards*, independent of workflow phases). No content is copied.

## How it works

- **Schema (Firebase, shared):** `boards/{id}/previousBoardId` + `nextBoardId` — a doubly-linked chain, adjacent paging only.
- **Header pager** (`← Previous / Next →`) appears only when a link exists; navigates via the existing `?board=` mechanism.
- **Start next board** (Settings → Share & Export): clones the current board's column structure + settings (empty cards), links the pointers, and jumps to the new board.
- **Link to previous board:** modal to pick a recent board or paste a board URL/ID.
- Fixes a latent nav bug: `BoardGate` is now keyed on `activeBoardId` so board→board navigation remounts the provider and re-subscribes to the new board.

## How to test (Netlify preview)

1. Open a board → **Settings → Share & Export → Start next board** → you land on a new board showing a **← Previous** control. Click it to page back; the original board now shows **Next →**.
2. On a different board, **Settings → Share & Export → Link to previous board** → paste a board URL/ID (or pick a recent board) → a **← Previous** control appears and pages back to it.

> ⚠️ The Netlify preview needs the `VITE_FIREBASE_*` env vars set in its build environment (the app throws without them). If the preview is blank, that's the cause.

## Verification

- ✅ Lint clean; production build compiles all modules.
- ✅ Unit tests: `useBoardSeries` (9) + `BoardSeriesPager` (5).
- ✅ **Live e2e against real Firebase**: `e2e/board-series.spec.js` (start-next + page back/forth, and link-to-previous via paste) — both pass. Runs in CI's `e2e-tests` job.

## Notes

- Documented the new schema in `AGENTS.md` and corrected the stale "Firebase config is hardcoded" note (it's env-var based now).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
