### PR TITLE
Fix mid-screen horizontal scrollbar on wide, short boards

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -244,7 +244,7 @@ function Board({ onGoHome, onNavigateToBoard }) {
   }
 
   return (
-    <div className={hasBackground ? 'board-has-background' : ''}>
+    <div className={hasBackground ? 'board-layout board-has-background' : 'board-layout'}>
       {hasBackground && <div className="board-background-layer" style={backgroundStyle} />}
 
       <header>

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,6 +5,24 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
+// jsdom in this environment does not provide Web Storage, so provide a
+// functional in-memory polyfill for code that reads/writes localStorage.
+if (typeof window !== 'undefined' && !window.localStorage) {
+  const createStorage = () => {
+    const store = new Map();
+    return {
+      getItem: key => (store.has(String(key)) ? store.get(String(key)) : null),
+      setItem: (key, value) => { store.set(String(key), String(value)); },
+      removeItem: key => { store.delete(String(key)); },
+      clear: () => { store.clear(); },
+      key: index => Array.from(store.keys())[index] ?? null,
+      get length() { return store.size; }
+    };
+  };
+  Object.defineProperty(window, 'localStorage', { value: createStorage(), configurable: true, writable: true });
+  Object.defineProperty(window, 'sessionStorage', { value: createStorage(), configurable: true, writable: true });
+}
+
 // Global mock for firebase utilities — individual tests can override with vi.mock
 vi.mock('./utils/firebase', () => {
   return {

--- a/src/styles/components/columns.css
+++ b/src/styles/components/columns.css
@@ -6,6 +6,13 @@
  */
 
 /* Main Board Layout */
+.board-layout {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-height: 0;
+}
+
 main {
   flex-grow: 1;
   padding: var(--space-sm) var(--space-md);


### PR DESCRIPTION
## Problem

On a board with many columns (wide) but few cards (short), an ugly horizontal scrollbar appeared in the **middle** of the screen with empty space below it.

## Cause

The board wrapper `<div>` in `Board.jsx` was a plain block element, breaking the flex chain between `.App` and `main#board-content`. `main` has `flex-grow: 1`, but with no flex parent to grow within, the board area collapsed to its content height. With short columns, `main`'s `overflow-x: auto` scrollbar landed mid-screen instead of at the viewport bottom.

## Fix

- Add a stable `.board-layout` class to the wrapper with a flex-column layout (`display: flex; flex-direction: column; flex-grow: 1; min-height: 0`). Now `main` fills the available height, columns stretch full height (they already had `height: 100%`), and the horizontal scrollbar sits at the bottom of the screen.

## Also included

- Add a functional in-memory `localStorage` polyfill in `setupTests.js`. jsdom doesn't provide Web Storage in this environment, which made the `useRecentBoards` and `ColumnsContainer` tests fail on `localStorage.clear()`. All 1396 tests now pass.

## Verification

- `npm run lint` — clean
- `npm run build` — succeeds
- `npm test` — 1396 passed (previously 16 failing)