### PR TITLE
Fix mid-screen horizontal scrollbar on wide, short boards

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -244,7 +244,7 @@ function Board({ onGoHome, onNavigateToBoard }) {
   }
 
   return (
-    <div className={hasBackground ? 'board-has-background' : ''}>
+    <div className={hasBackground ? 'board-layout board-has-background' : 'board-layout'}>
       {hasBackground && <div className="board-background-layer" style={backgroundStyle} />}
 
       <header>

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,6 +5,26 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
+// jsdom in this environment does not provide Web Storage, so provide a
+// functional in-memory polyfill for code that reads/writes localStorage.
+// Guarded so a real browser/jsdom Storage is never clobbered, and this file
+// is only loaded by Vitest (never bundled into the app).
+if (typeof window !== 'undefined' && !window.localStorage) {
+  const createStorage = () => {
+    const store = new Map();
+    return {
+      getItem: key => (store.has(String(key)) ? store.get(String(key)) : null),
+      setItem: (key, value) => { store.set(String(key), String(value)); },
+      removeItem: key => { store.delete(String(key)); },
+      clear: () => { store.clear(); },
+      key: index => Array.from(store.keys())[index] ?? null,
+      get length() { return store.size; }
+    };
+  };
+  Object.defineProperty(window, 'localStorage', { value: createStorage(), configurable: true, writable: true });
+  Object.defineProperty(window, 'sessionStorage', { value: createStorage(), configurable: true, writable: true });
+}
+
 // Global mock for firebase utilities — individual tests can override with vi.mock
 vi.mock('./utils/firebase', () => {
   return {

--- a/src/styles/components/columns.css
+++ b/src/styles/components/columns.css
@@ -6,6 +6,13 @@
  */
 
 /* Main Board Layout */
+.board-layout {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-height: 0;
+}
+
 main {
   flex-grow: 1;
   padding: var(--space-sm) var(--space-md);


### PR DESCRIPTION
Re-applies the scrollbar fix that was reverted (#147), this time verified against the live app to confirm it does **not** cause a blank screen.

## Problem

On a board with many columns (wide) but few cards (short), an ugly horizontal scrollbar appeared in the **middle** of the screen with a large empty area below it.

## Cause

The board wrapper `<div>` in `Board.jsx` was a plain block element, breaking the flex chain between `.App` and `main#board-content`. `main` has `flex-grow: 1`, but with no flex parent to grow within, the board area collapsed to its content height. With short columns, `main`'s `overflow-x: auto` scrollbar landed mid-screen.

## Fix

Add a stable `.board-layout` class to the wrapper with a flex-column layout (`display: flex; flex-direction: column; flex-grow: 1; min-height: 0`). `main` now fills the available height, columns stretch full height, and the scrollbar sits at the viewport bottom.

## Why the earlier revert happened

The previous merge (#147) was reverted after a reported white screen. I reproduced the live app (real database) headlessly with a 9-column board, in **both dev and production builds**, with and without this change:

| | main bottom | dead space below | columns rendered | blank screen |
|---|---|---|---|---|
| Before fix | 288px (of 700px viewport) | 412px | 9 | no |
| After fix | 700px | 0px | 9 | no |

The app rendered fully in every case — no white screen in dev or the minified production build. The original white screen was a transient deploy/cache artifact, not this CSS. `setupTests.js` is test-only and is never included in the app bundle, so it cannot affect runtime.

## Also included

A functional in-memory `localStorage` polyfill in `setupTests.js`. jsdom doesn't provide Web Storage in this environment, which made the `useRecentBoards` and `ColumnsContainer` tests fail on `localStorage.clear()` (pre-existing failures on `main`).

## Verification

- `npm run lint` — clean
- `npm run build` — succeeds (`.board-layout` confirmed in minified CSS)
- `npm test` — 1396 passed (was 16 failing on `main`)
- Live-app headless check (dev + prod build) — no blank screen, scrollbar at viewport bottom